### PR TITLE
Enhancement: Allow to assert that classes, interfaces, and traits exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ final class PlayerTest extends TestCase
 } 
 ```
 
+### Additional Assertions
+
+In addition to the assertions made available by extending from `PHPUnit\Framework\TestCase`, 
+the `Helper` trait provides the following assertions:
+
+* `assertClassExists(string $className)`
+* `assertInterfaceExists(string $className)`
+* `assertTraitExists(string $className)`
+
 ## Contributing
 
 Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -32,4 +32,28 @@ trait Helper
 
         return $fakers[$locale];
     }
+
+    final protected function assertClassExists(string $className)
+    {
+        $this->assertTrue(\class_exists($className), \sprintf(
+            'Failed to assert that a class "%s" exists',
+            $className
+        ));
+    }
+
+    final protected function assertInterfaceExists(string $className)
+    {
+        $this->assertTrue(\interface_exists($className), \sprintf(
+            'Failed to assert that an interface "%s" exists',
+            $className
+        ));
+    }
+
+    final protected function assertTraitExists(string $className)
+    {
+        $this->assertTrue(\trait_exists($className), \sprintf(
+            'Failed to assert that a trait "%s" exists',
+            $className
+        ));
+    }
 }

--- a/test/Unit/Fixture/AClass.php
+++ b/test/Unit/Fixture/AClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+final class AClass
+{
+}

--- a/test/Unit/Fixture/ATrait.php
+++ b/test/Unit/Fixture/ATrait.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+trait ATrait
+{
+}

--- a/test/Unit/Fixture/AnInterface.php
+++ b/test/Unit/Fixture/AnInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+interface AnInterface
+{
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -77,6 +77,156 @@ final class HelperTest extends Framework\TestCase
         }
     }
 
+    public function testClassExistsFailsWhenClassDoesNotExist()
+    {
+        $className = __NAMESPACE__ . '\Fixture\NonExistentClass';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists',
+            $className
+        ));
+
+        $this->assertClassExists($className);
+    }
+
+    /**
+     * @dataProvider providerNotAClass
+     *
+     * @param string $className
+     */
+    public function testClassExistsFailsWhenClassIsNotAClass(string $className)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists',
+            $className
+        ));
+
+        $this->assertClassExists($className);
+    }
+
+    public function providerNotAClass(): \Generator
+    {
+        $classNames = [
+            Fixture\AnInterface::class,
+            Fixture\ATrait::class,
+        ];
+
+        foreach ($classNames as $className) {
+            yield [
+                $className,
+            ];
+        }
+    }
+
+    public function testClassExistsSucceedsWhenClassExists()
+    {
+        $className = Fixture\AClass::class;
+
+        $this->assertClassExists($className);
+    }
+
+    public function testInterfaceExistsFailsWhenInterfaceDoesNotExist()
+    {
+        $className = __NAMESPACE__ . '\Fixture\NonExistentInterface';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that an interface "%s" exists',
+            $className
+        ));
+
+        $this->assertInterfaceExists($className);
+    }
+
+    /**
+     * @dataProvider providerNotAnInterface
+     *
+     * @param string $className
+     */
+    public function testInterfaceExistsFailsWhenInterfaceIsNotAInterface(string $className)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that an interface "%s" exists',
+            $className
+        ));
+
+        $this->assertInterfaceExists($className);
+    }
+
+    public function providerNotAnInterface(): \Generator
+    {
+        $classNames = [
+            Fixture\AClass::class,
+            Fixture\ATrait::class,
+        ];
+
+        foreach ($classNames as $className) {
+            yield [
+                $className,
+            ];
+        }
+    }
+
+    public function testInterfaceExistsSucceedsWhenInterfaceExists()
+    {
+        $className = Fixture\AnInterface::class;
+
+        $this->assertInterfaceExists($className);
+    }
+
+    public function testTraitExistsFailsWhenTraitDoesNotExist()
+    {
+        $className = __NAMESPACE__ . '\Fixture\NonExistentTrait';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a trait "%s" exists',
+            $className
+        ));
+
+        $this->assertTraitExists($className);
+    }
+
+    /**
+     * @dataProvider providerNotATrait
+     *
+     * @param string $className
+     */
+    public function testTraitExistsFailsWhenTraitIsNotATrait(string $className)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a trait "%s" exists',
+            $className
+        ));
+
+        $this->assertTraitExists($className);
+    }
+
+    public function providerNotATrait(): \Generator
+    {
+        $classNames = [
+            Fixture\AClass::class,
+            Fixture\AnInterface::class,
+        ];
+
+        foreach ($classNames as $className) {
+            yield [
+                $className,
+            ];
+        }
+    }
+
+    public function testTraitExistsSucceedsWhenTraitExists()
+    {
+        $className = Fixture\ATrait::class;
+
+        $this->assertTraitExists($className);
+    }
+
     private function assertHasOnlyProvidersWithLocale(string $locale, Generator $faker)
     {
         $providerClasses = \array_map(function (Provider\Base $provider) {


### PR DESCRIPTION
This PR

* [x] adds assertions `assertClassExists()`, `assertInterfaceExists()`, and `assertTraitExists()`