### PR TITLE
Enhancement: Allow to assert that a class is abstract or final

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ In addition to the assertions made available by extending from `PHPUnit\Framewor
 the `Helper` trait provides the following assertions:
 
 * `assertClassExists(string $className)`
+* `assertClassIsAbstractOrFinal(string $className)`
 * `assertInterfaceExists(string $className)`
 * `assertTraitExists(string $className)`
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -41,6 +41,18 @@ trait Helper
         ));
     }
 
+    final protected function assertClassIsAbstractOrFinal(string $className)
+    {
+        $this->assertClassExists($className);
+
+        $reflection = new \ReflectionClass($className);
+
+        $this->assertTrue($reflection->isAbstract() || $reflection->isFinal(), \sprintf(
+            'Failed to assert that class "%s" is abstract or final',
+            $className
+        ));
+    }
+
     final protected function assertInterfaceExists(string $className)
     {
         $this->assertTrue(\interface_exists($className), \sprintf(

--- a/test/Unit/Fixture/AbstractClass.php
+++ b/test/Unit/Fixture/AbstractClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+abstract class AbstractClass
+{
+}

--- a/test/Unit/Fixture/FinalClass.php
+++ b/test/Unit/Fixture/FinalClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+final class FinalClass
+{
+}

--- a/test/Unit/Fixture/NonFinalClass.php
+++ b/test/Unit/Fixture/NonFinalClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+class NonFinalClass
+{
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -127,6 +127,62 @@ final class HelperTest extends Framework\TestCase
         $this->assertClassExists($className);
     }
 
+    public function testClassIsAbstractOrFinalFailsWhenClassDoesNotExist()
+    {
+        $className = __NAMESPACE__ . '\Fixture\NonExistentClass';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists',
+            $className
+        ));
+
+        $this->assertClassIsAbstractOrFinal($className);
+    }
+
+    /**
+     * @dataProvider providerNotAClass
+     *
+     * @param string $className
+     */
+    public function testClassIsAbstractOrFinalFailsWhenClassIsNotAClass(string $className)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists',
+            $className
+        ));
+
+        $this->assertClassIsAbstractOrFinal($className);
+    }
+
+    public function testClassIsAbstractOrFinalFailsWhenClassIsNeitherAbstractNorFinal()
+    {
+        $className = Fixture\NonFinalClass::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that class "%s" is abstract or final',
+            $className
+        ));
+
+        $this->assertClassIsAbstractOrFinal($className);
+    }
+
+    public function providerClassAbstractOrFinal(): \Generator
+    {
+        $classNames = [
+            Fixture\AbstractClass::class,
+            Fixture\FinalClass::class,
+        ];
+
+        foreach ($classNames as $className) {
+            yield [
+                $className,
+            ];
+        }
+    }
+
     public function testInterfaceExistsFailsWhenInterfaceDoesNotExist()
     {
         $className = __NAMESPACE__ . '\Fixture\NonExistentInterface';


### PR DESCRIPTION
This PR

* [x] adds `assertClassIsAbstractOrFinal()`
