### PR TITLE
Enhancement: Allow to assert that classes and interfaces extend other classes and interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ In addition to the assertions made available by extending from `PHPUnit\Framewor
 the `Helper` trait provides the following assertions:
 
 * `assertClassExists(string $className)`
+* `assertClassExtends(string $parentClassName, string $className)`
 * `assertClassImplementsInterface(string $interfaceName, string $className)`
 * `assertClassIsAbstractOrFinal(string $className)`
 * `assertInterfaceExists(string $interfaceName)`
+* `assertInterfaceExtends(string $parentInterfaceName, string $interfaceName)`
 * `assertTraitExists(string $traitName)`
 
 ## Contributing

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -41,6 +41,20 @@ trait Helper
         ));
     }
 
+    final protected function assertClassExtends(string $parentClassName, string $className)
+    {
+        $this->assertClassExists($parentClassName);
+        $this->assertClassExists($className);
+
+        $reflection = new \ReflectionClass($className);
+
+        $this->assertTrue($reflection->isSubclassOf($parentClassName), \sprintf(
+            'Failed to assert that class "%s" extends "%s"',
+            $className,
+            $parentClassName
+        ));
+    }
+
     final protected function assertClassImplementsInterface(string $interfaceName, string $className)
     {
         $this->assertInterfaceExists($interfaceName);
@@ -72,6 +86,20 @@ trait Helper
         $this->assertTrue(\interface_exists($interfaceName), \sprintf(
             'Failed to assert that an interface "%s" exists',
             $interfaceName
+        ));
+    }
+
+    final protected function assertInterfaceExtends(string $parentInterfaceName, string $interfaceName)
+    {
+        $this->assertInterfaceExists($parentInterfaceName);
+        $this->assertInterfaceExists($interfaceName);
+
+        $reflection = new \ReflectionClass($interfaceName);
+
+        $this->assertTrue($reflection->isSubclassOf($parentInterfaceName), \sprintf(
+            'Failed to assert that interface "%s" extends "%s"',
+            $interfaceName,
+            $parentInterfaceName
         ));
     }
 

--- a/test/Unit/Fixture/ClassExtendingParentClass.php
+++ b/test/Unit/Fixture/ClassExtendingParentClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+final class ClassExtendingParentClass extends AbstractClass
+{
+}

--- a/test/Unit/Fixture/ClassNotExtendingParentClass.php
+++ b/test/Unit/Fixture/ClassNotExtendingParentClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+final class ClassNotExtendingParentClass
+{
+}

--- a/test/Unit/Fixture/InterfaceExtendingParentInterface.php
+++ b/test/Unit/Fixture/InterfaceExtendingParentInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+interface InterfaceExtendingParentInterface extends ExampleInterface
+{
+}

--- a/test/Unit/Fixture/InterfaceNotExtendingParentInterface.php
+++ b/test/Unit/Fixture/InterfaceNotExtendingParentInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+interface InterfaceNotExtendingParentInterface
+{
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -127,6 +127,69 @@ final class HelperTest extends Framework\TestCase
         $this->assertClassExists($className);
     }
 
+    public function testAssertClassExtendsFailsWhenParentClassDoesNotExist()
+    {
+        $parentClassName = __NAMESPACE__ . '\Fixture\NonExistentClass';
+        $className = Fixture\ExampleClass::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists',
+            $parentClassName
+        ));
+
+        $this->assertClassExtends(
+            $parentClassName,
+            $className
+        );
+    }
+
+    public function testAssertClassExtendsFailsWhenClassDoesNotExist()
+    {
+        $parentClassName = Fixture\AbstractClass::class;
+        $className = __NAMESPACE__ . '\Fixture\NonExistentClass';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists',
+            $className
+        ));
+
+        $this->assertClassExtends(
+            $parentClassName,
+            $className
+        );
+    }
+
+    public function testClassExtendsFailsWhenClassDoesNotExtendParentClass()
+    {
+        $parentClassName = Fixture\AbstractClass::class;
+        $className = Fixture\ClassNotExtendingParentClass::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that class "%s" extends "%s"',
+            $className,
+            $parentClassName
+        ));
+
+        $this->assertClassExtends(
+            $parentClassName,
+            $className
+        );
+    }
+
+    public function testAssertClassExtendsSucceedsWhenClassExtendsParentClass()
+    {
+        $parentClassName = Fixture\AbstractClass::class;
+        $className = Fixture\ClassExtendingParentClass::class;
+
+        $this->assertClassExtends(
+            $parentClassName,
+            $className
+        );
+    }
+
     public function testAssertClassImplementsInterfaceFailsWhenInterfaceDoesNotExist()
     {
         $interfaceName = __NAMESPACE__ . '\Fixture\NonExistentInterface';
@@ -294,6 +357,69 @@ final class HelperTest extends Framework\TestCase
         $interfaceName = Fixture\ExampleInterface::class;
 
         $this->assertInterfaceExists($interfaceName);
+    }
+
+    public function testInterfaceExtendsFailsWhenParentInterfaceDoesNotExist()
+    {
+        $parentInterfaceName = __NAMESPACE__ . '\Fixture\NonExistentInterface';
+        $interfaceName = Fixture\ExampleInterface::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that an interface "%s" exists',
+            $parentInterfaceName
+        ));
+
+        $this->assertInterfaceExtends(
+            $parentInterfaceName,
+            $interfaceName
+        );
+    }
+
+    public function testAssertInterfaceExtendsFailsWhenInterfaceDoesNotExist()
+    {
+        $parentInterfaceName = Fixture\ExampleInterface::class;
+        $interfaceName = __NAMESPACE__ . '\Fixture\NonExistentInterface';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that an interface "%s" exists',
+            $interfaceName
+        ));
+
+        $this->assertInterfaceExtends(
+            $parentInterfaceName,
+            $interfaceName
+        );
+    }
+
+    public function testAssertInterfaceExtendsFailsWhenInterfaceDoesNotExtendParentInterface()
+    {
+        $parentInterfaceName = Fixture\ExampleInterface::class;
+        $interfaceName = Fixture\InterfaceNotExtendingParentInterface::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that interface "%s" extends "%s"',
+            $interfaceName,
+            $parentInterfaceName
+        ));
+
+        $this->assertInterfaceExtends(
+            $parentInterfaceName,
+            $interfaceName
+        );
+    }
+
+    public function testAssertInterfaceExtendsSucceedsWhenInterfaceExtendsParentInterface()
+    {
+        $parentInterfaceName = Fixture\ExampleInterface::class;
+        $interfaceName = Fixture\InterfaceExtendingParentInterface::class;
+
+        $this->assertInterfaceExtends(
+            $parentInterfaceName,
+            $interfaceName
+        );
     }
 
     public function testAssertTraitExistsFailsWhenTraitDoesNotExist()


### PR DESCRIPTION
This PR

* [x] adds `assertClassExtends()` and `assertInterfaceExtends()`