### PR TITLE
Enhancement: Allow to assert that a class uses a trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ the `Helper` trait provides the following assertions:
 * `assertClassExtends(string $parentClassName, string $className)`
 * `assertClassImplementsInterface(string $interfaceName, string $className)`
 * `assertClassIsAbstractOrFinal(string $className)`
+* `assertClassUsesTrait(string $traitName, string $className)`
 * `assertInterfaceExists(string $interfaceName)`
 * `assertInterfaceExtends(string $parentInterfaceName, string $interfaceName)`
 * `assertTraitExists(string $traitName)`

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -81,6 +81,18 @@ trait Helper
         ));
     }
 
+    final protected function assertClassUsesTrait(string $traitName, string $className)
+    {
+        $this->assertTraitExists($traitName);
+        $this->assertClassExists($className);
+
+        $this->assertContains($traitName, \class_uses($className), \sprintf(
+            'Failed to assert that class "%s" uses trait "%s"',
+            $className,
+            $traitName
+        ));
+    }
+
     final protected function assertInterfaceExists(string $interfaceName)
     {
         $this->assertTrue(\interface_exists($interfaceName), \sprintf(

--- a/test/Unit/Fixture/ClassNotUsingTrait.php
+++ b/test/Unit/Fixture/ClassNotUsingTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+final class ClassNotUsingTrait
+{
+}

--- a/test/Unit/Fixture/ClassUsingTrait.php
+++ b/test/Unit/Fixture/ClassUsingTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Fixture;
+
+final class ClassUsingTrait
+{
+    use ExampleTrait;
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -309,6 +309,69 @@ final class HelperTest extends Framework\TestCase
         }
     }
 
+    public function testAssertClassUsesTraitFailsWhenTraitDoesNotExist()
+    {
+        $traitName = __NAMESPACE__ . '\Fixture\NonExistentTrait';
+        $className = Fixture\ExampleClass::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a trait "%s" exists',
+            $traitName
+        ));
+
+        $this->assertClassUsesTrait(
+            $traitName,
+            $className
+        );
+    }
+
+    public function testAssertClassUsesTraitFailsWhenClassDoesNotExist()
+    {
+        $traitName = Fixture\ExampleTrait::class;
+        $className = __NAMESPACE__ . '\Fixture\NonExistentClass';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists',
+            $className
+        ));
+
+        $this->assertClassUsesTrait(
+            $traitName,
+            $className
+        );
+    }
+
+    public function testAssertClassUsesTraitFailsWhenClassDoesNotUseTrait()
+    {
+        $traitName = Fixture\ExampleTrait::class;
+        $className = Fixture\ClassNotUsingTrait::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that class "%s" uses trait "%s"',
+            $className,
+            $traitName
+        ));
+
+        $this->assertClassUsesTrait(
+            $traitName,
+            $className
+        );
+    }
+
+    public function testAssertClassUsesTraitSucceedsWhenClassUsesTrait()
+    {
+        $traitName = Fixture\ExampleTrait::class;
+        $className = Fixture\ClassUsingTrait::class;
+
+        $this->assertClassUsesTrait(
+            $traitName,
+            $className
+        );
+    }
+
     public function testAssertInterfaceExistsFailsWhenInterfaceDoesNotExist()
     {
         $interfaceName = __NAMESPACE__ . '\Fixture\NonExistentInterface';


### PR DESCRIPTION
This PR

* [x] adds `assertClassUsesTrait()`