### PR TITLE
Enhancement: Allow to assert that classes, interfaces, and traits satisfy specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,13 @@ the `Helper` trait provides the following assertions:
 * `assertClassExtends(string $parentClassName, string $className)`
 * `assertClassImplementsInterface(string $interfaceName, string $className)`
 * `assertClassIsAbstractOrFinal(string $className)`
+* `assertClassSatisfiesSpecification(callable $specification, string $className, string $message = '')`
 * `assertClassUsesTrait(string $traitName, string $className)`
 * `assertInterfaceExists(string $interfaceName)`
 * `assertInterfaceExtends(string $parentInterfaceName, string $interfaceName)`
+* `assertInterfaceSatisfiesSpecification(callable $specification, string $interfaceName, string $message = '')`
 * `assertTraitExists(string $traitName)`
+* `assertTraitSatisfiesSpecification(callable $specification, string $traitName, string $message = '')`
 
 ## Contributing
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -214,6 +214,16 @@ trait Helper
         ));
     }
 
+    final protected function assertClassSatisfiesSpecification(callable $specification, string $className, string $message = '')
+    {
+        $this->assertClassExists($className);
+
+        $this->assertTrue($specification($className), \sprintf(
+            '' !== $message ? $message : 'Failed to assert that class "%s" satisfies a specification.',
+            $className
+        ));
+    }
+
     final protected function assertClassUsesTrait(string $traitName, string $className)
     {
         $this->assertTraitExists($traitName);
@@ -248,10 +258,30 @@ trait Helper
         ));
     }
 
+    final protected function assertInterfaceSatisfiesSpecification(callable $specification, string $interfaceName, string $message = '')
+    {
+        $this->assertInterfaceExists($interfaceName);
+
+        $this->assertTrue($specification($interfaceName), \sprintf(
+            '' !== $message ? $message : 'Failed to assert that interface "%s" satisfies a specification.',
+            $interfaceName
+        ));
+    }
+
     final protected function assertTraitExists(string $traitName)
     {
         $this->assertTrue(\trait_exists($traitName), \sprintf(
             'Failed to assert that a trait "%s" exists.',
+            $traitName
+        ));
+    }
+
+    final protected function assertTraitSatisfiesSpecification(callable $specification, string $traitName, string $message = '')
+    {
+        $this->assertTraitExists($traitName);
+
+        $this->assertTrue($specification($traitName), \sprintf(
+            '' !== $message ? $message : 'Failed to assert that trait "%s" satisfies a specification.',
             $traitName
         ));
     }

--- a/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
+++ b/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassSatisfiesSpecification;
+
+final class ExampleClass
+{
+}

--- a/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
+++ b/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\InterfaceSatisfiesSpecification;
+
+interface ExampleInterface
+{
+}

--- a/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
+++ b/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\TraitSatisfiesSpecification;
+
+trait ExampleTrait
+{
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -744,6 +744,77 @@ final class HelperTest extends Framework\TestCase
     }
 
     /**
+     * @dataProvider providerNotClass
+     *
+     * @param string $className
+     */
+    public function testAssertClassSatisfiesSpecificationFailsWhenClassIsNotAClass(string $className)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists',
+            $className
+        ));
+
+        $this->assertClassSatisfiesSpecification(
+            function () {
+                return true;
+            },
+            $className
+        );
+    }
+
+    public function testAssertClassSatisfiesSpecificationFailsWhenSpecificationReturnsFalse()
+    {
+        $className = Fixture\ClassSatisfiesSpecification\ExampleClass::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that class "%s" satisfies a specification.',
+            $className
+        ));
+
+        $this->assertClassSatisfiesSpecification(
+            function () {
+                return false;
+            },
+            $className
+        );
+    }
+
+    public function testAssertClassSatisfiesSpecificationFailsWhenSpecificationReturnsFalseAndUsesMessage()
+    {
+        $className = Fixture\ClassSatisfiesSpecification\ExampleClass::class;
+        $message = 'Looks like "%s" does not satisfy our requirements right now';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            $message,
+            $className
+        ));
+
+        $this->assertClassSatisfiesSpecification(
+            function () {
+                return false;
+            },
+            $className,
+            $message
+        );
+    }
+
+    public function testAssertClassSatisfiesSpecificationSucceedsWhenSpecificationReturnsTrue()
+    {
+        $className = Fixture\ClassSatisfiesSpecification\ExampleClass::class;
+
+        $this->assertClassSatisfiesSpecification(
+            function () {
+                return true;
+            },
+            $className
+        );
+    }
+
+    /**
      * @dataProvider providerNotTrait
      *
      * @param string $traitName
@@ -924,6 +995,77 @@ final class HelperTest extends Framework\TestCase
     }
 
     /**
+     * @dataProvider providerNotInterface
+     *
+     * @param string $interfaceName
+     */
+    public function testAssertInterfaceSatisfiesSpecificationFailsWhenInterfaceIsNotAInterface(string $interfaceName)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that an interface "%s" exists',
+            $interfaceName
+        ));
+
+        $this->assertInterfaceSatisfiesSpecification(
+            function () {
+                return true;
+            },
+            $interfaceName
+        );
+    }
+
+    public function testAssertInterfaceSatisfiesSpecificationFailsWhenSpecificationReturnsFalse()
+    {
+        $interfaceName = Fixture\InterfaceSatisfiesSpecification\ExampleInterface::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that interface "%s" satisfies a specification.',
+            $interfaceName
+        ));
+
+        $this->assertInterfaceSatisfiesSpecification(
+            function () {
+                return false;
+            },
+            $interfaceName
+        );
+    }
+
+    public function testAssertInterfaceSatisfiesSpecificationFailsWhenSpecificationReturnsFalseAndUsesMessage()
+    {
+        $interfaceName = Fixture\InterfaceSatisfiesSpecification\ExampleInterface::class;
+        $message = 'Looks like "%s" does not satisfy our requirements right now';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            $message,
+            $interfaceName
+        ));
+
+        $this->assertInterfaceSatisfiesSpecification(
+            function () {
+                return false;
+            },
+            $interfaceName,
+            $message
+        );
+    }
+
+    public function testAssertInterfaceSatisfiesSpecificationSucceedsWhenSpecificationReturnsTrue()
+    {
+        $interfaceName = Fixture\InterfaceSatisfiesSpecification\ExampleInterface::class;
+
+        $this->assertInterfaceSatisfiesSpecification(
+            function () {
+                return true;
+            },
+            $interfaceName
+        );
+    }
+
+    /**
      * @dataProvider providerNotTrait
      *
      * @param string $traitName
@@ -959,6 +1101,77 @@ final class HelperTest extends Framework\TestCase
         $traitName = Fixture\TraitExists\ExampleTrait::class;
 
         $this->assertTraitExists($traitName);
+    }
+
+    /**
+     * @dataProvider providerNotTrait
+     *
+     * @param string $traitName
+     */
+    public function testAssertTraitSatisfiesSpecificationFailsWhenTraitIsNotATrait(string $traitName)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a trait "%s" exists',
+            $traitName
+        ));
+
+        $this->assertTraitSatisfiesSpecification(
+            function () {
+                return true;
+            },
+            $traitName
+        );
+    }
+
+    public function testAssertTraitSatisfiesSpecificationFailsWhenSpecificationReturnsFalse()
+    {
+        $traitName = Fixture\TraitSatisfiesSpecification\ExampleTrait::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that trait "%s" satisfies a specification.',
+            $traitName
+        ));
+
+        $this->assertTraitSatisfiesSpecification(
+            function () {
+                return false;
+            },
+            $traitName
+        );
+    }
+
+    public function testAssertTraitSatisfiesSpecificationFailsWhenSpecificationReturnsFalseAndUsesMessage()
+    {
+        $traitName = Fixture\TraitSatisfiesSpecification\ExampleTrait::class;
+        $message = 'Looks like "%s" does not satisfy our requirements right now';
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            $message,
+            $traitName
+        ));
+
+        $this->assertTraitSatisfiesSpecification(
+            function () {
+                return false;
+            },
+            $traitName,
+            $message
+        );
+    }
+
+    public function testAssertTraitSatisfiesSpecificationSucceedsWhenSpecificationReturnsTrue()
+    {
+        $traitName = Fixture\TraitSatisfiesSpecification\ExampleTrait::class;
+
+        $this->assertTraitSatisfiesSpecification(
+            function () {
+                return true;
+            },
+            $traitName
+        );
     }
 
     private function assertHasOnlyProvidersWithLocale(string $locale, Generator $faker)


### PR DESCRIPTION
This PR

* [x] adds `assertClassSatisfiesSpecification()`, `assertInterfaceSatisfiesSpecification()`, and `assertTraitSatisfiesSpecification()`