### PR TITLE
Fix: Consistently end assertion messages with a period

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -36,7 +36,7 @@ trait Helper
     final protected function assertClassExists(string $className)
     {
         $this->assertTrue(\class_exists($className), \sprintf(
-            'Failed to assert that a class "%s" exists',
+            'Failed to assert that a class "%s" exists.',
             $className
         ));
     }
@@ -49,7 +49,7 @@ trait Helper
         $reflection = new \ReflectionClass($className);
 
         $this->assertTrue($reflection->isSubclassOf($parentClassName), \sprintf(
-            'Failed to assert that class "%s" extends "%s"',
+            'Failed to assert that class "%s" extends "%s".',
             $className,
             $parentClassName
         ));
@@ -63,7 +63,7 @@ trait Helper
         $reflection = new \ReflectionClass($className);
 
         $this->assertTrue($reflection->implementsInterface($interfaceName), \sprintf(
-            'Failed to assert that class "%s" implements interface "%s"',
+            'Failed to assert that class "%s" implements interface "%s".',
             $className,
             $interfaceName
         ));
@@ -76,7 +76,7 @@ trait Helper
         $reflection = new \ReflectionClass($className);
 
         $this->assertTrue($reflection->isAbstract() || $reflection->isFinal(), \sprintf(
-            'Failed to assert that class "%s" is abstract or final',
+            'Failed to assert that class "%s" is abstract or final.',
             $className
         ));
     }
@@ -87,7 +87,7 @@ trait Helper
         $this->assertClassExists($className);
 
         $this->assertContains($traitName, \class_uses($className), \sprintf(
-            'Failed to assert that class "%s" uses trait "%s"',
+            'Failed to assert that class "%s" uses trait "%s".',
             $className,
             $traitName
         ));
@@ -96,7 +96,7 @@ trait Helper
     final protected function assertInterfaceExists(string $interfaceName)
     {
         $this->assertTrue(\interface_exists($interfaceName), \sprintf(
-            'Failed to assert that an interface "%s" exists',
+            'Failed to assert that an interface "%s" exists.',
             $interfaceName
         ));
     }
@@ -109,7 +109,7 @@ trait Helper
         $reflection = new \ReflectionClass($interfaceName);
 
         $this->assertTrue($reflection->isSubclassOf($parentInterfaceName), \sprintf(
-            'Failed to assert that interface "%s" extends "%s"',
+            'Failed to assert that interface "%s" extends "%s".',
             $interfaceName,
             $parentInterfaceName
         ));
@@ -118,7 +118,7 @@ trait Helper
     final protected function assertTraitExists(string $traitName)
     {
         $this->assertTrue(\trait_exists($traitName), \sprintf(
-            'Failed to assert that a trait "%s" exists',
+            'Failed to assert that a trait "%s" exists.',
             $traitName
         ));
     }

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -86,7 +86,7 @@ final class HelperTest extends Framework\TestCase
     {
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that a class "%s" exists',
+            'Failed to assert that a class "%s" exists.',
             $className
         ));
 
@@ -126,7 +126,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that a class "%s" exists',
+            'Failed to assert that a class "%s" exists.',
             $parentClassName
         ));
 
@@ -147,7 +147,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that a class "%s" exists',
+            'Failed to assert that a class "%s" exists.',
             $className
         ));
 
@@ -164,7 +164,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that class "%s" extends "%s"',
+            'Failed to assert that class "%s" extends "%s".',
             $className,
             $parentClassName
         ));
@@ -197,7 +197,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that an interface "%s" exists',
+            'Failed to assert that an interface "%s" exists.',
             $interfaceName
         ));
 
@@ -218,7 +218,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that a class "%s" exists',
+            'Failed to assert that a class "%s" exists.',
             $className
         ));
 
@@ -235,7 +235,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that class "%s" implements interface "%s"',
+            'Failed to assert that class "%s" implements interface "%s".',
             $className,
             $interfaceName
         ));
@@ -266,7 +266,7 @@ final class HelperTest extends Framework\TestCase
     {
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that a class "%s" exists',
+            'Failed to assert that a class "%s" exists.',
             $className
         ));
 
@@ -279,7 +279,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that class "%s" is abstract or final',
+            'Failed to assert that class "%s" is abstract or final.',
             $className
         ));
 
@@ -311,7 +311,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that a trait "%s" exists',
+            'Failed to assert that a trait "%s" exists.',
             $traitName
         ));
 
@@ -332,7 +332,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that a class "%s" exists',
+            'Failed to assert that a class "%s" exists.',
             $className
         ));
 
@@ -349,7 +349,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that class "%s" uses trait "%s"',
+            'Failed to assert that class "%s" uses trait "%s".',
             $className,
             $traitName
         ));
@@ -380,7 +380,7 @@ final class HelperTest extends Framework\TestCase
     {
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that an interface "%s" exists',
+            'Failed to assert that an interface "%s" exists.',
             $interfaceName
         ));
 
@@ -420,7 +420,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that an interface "%s" exists',
+            'Failed to assert that an interface "%s" exists.',
             $parentInterfaceName
         ));
 
@@ -441,7 +441,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that an interface "%s" exists',
+            'Failed to assert that an interface "%s" exists.',
             $interfaceName
         ));
 
@@ -458,7 +458,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that interface "%s" extends "%s"',
+            'Failed to assert that interface "%s" extends "%s".',
             $interfaceName,
             $parentInterfaceName
         ));
@@ -489,7 +489,7 @@ final class HelperTest extends Framework\TestCase
     {
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that a trait "%s" exists',
+            'Failed to assert that a trait "%s" exists.',
             $traitName
         ));
 


### PR DESCRIPTION
This PR

* [x] consistently ends assertion messages with a period