### PR TITLE
Enhancement: Trigger E_USER_ERROR when fzaninotto/faker is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ final class BazTest extends TestCase
 Assuming you have installed [`fzaninotto/faker`](https://github.com/fzaninotto/Faker), 
 the `Helper` trait provides a method to fetch a localized instance of `Faker\Generator`:
 
-* `faker(string $locale = \Faker\Factory::DEFAULT_LOCALE) : \Faker\Generator`
+* `faker(string $locale = 'en_US') : \Faker\Generator`
 
 ```php
 <?php

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -18,9 +18,20 @@ use Faker\Generator;
 
 trait Helper
 {
-    final protected function faker(string $locale = Factory::DEFAULT_LOCALE): Generator
+    final protected function faker(string $locale = 'en_US'): Generator
     {
         static $fakers = [];
+
+        if (false === \class_exists(Generator::class)) {
+            \trigger_error(
+                \sprintf(
+                    'For using the method "%s()", the package "%s" needs to be installed, but it appears that it is not.',
+                    __METHOD__,
+                    'fzaninotto/faker'
+                ),
+                E_USER_ERROR
+            );
+        }
 
         if (!\array_key_exists($locale, $fakers)) {
             $faker = Factory::create($locale);


### PR DESCRIPTION
This PR

* [x] triggers an `E_USER_ERROR` when `fzaninotto/faker` is not installed