### PR TITLE
Fix: Configure composer to optimize autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     }
   ],
   "config": {
+    "optimize-autoloader": true,
     "preferred-install": "dist",
     "sort-packages": true
   },


### PR DESCRIPTION
This PR

* [x] configures `composer` to optimize the autoloader

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#optimize-autoloader.