### PR TITLE
Fix: Ignore non-existent exclude classes

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -121,17 +121,6 @@ trait Helper
 
         $directory = \realpath($directory);
 
-        $nonExistentExcludeClassNames = \array_filter($excludeClassNames, function (string $excludeClassName) {
-            return false === \class_exists($excludeClassName);
-        });
-
-        if (0 < \count($nonExistentExcludeClassNames)) {
-            throw new \InvalidArgumentException(\sprintf(
-                'Exclude class names need to be specified as existing classes, but "%s" does not exist.',
-                \implode('", "', $excludeClassNames)
-            ));
-        }
-
         $classFileLocator = new File\ClassFileLocator($directory);
 
         /** @var File\PhpClassFile[] $classFiles */

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -207,6 +207,21 @@ final class HelperTest extends Framework\TestCase
         );
     }
 
+    public function testAssertClassesAreAbstractOrFinalWithExcludeClassNamesIgnoresNonExistentExcludeClassNames()
+    {
+        $directory = __DIR__ . '/../Fixture/ClassesAreAbstractOrFinal';
+        $excludeClassNames = [
+            Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\AlsoNeitherAbstractNorFinal::class,
+            Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\NeitherAbstractNorFinal::class,
+            __NAMESPACE__ . '\\NonExistentClass',
+        ];
+
+        $this->assertClassesAreAbstractOrFinal(
+            $directory,
+            $excludeClassNames
+        );
+    }
+
     public function testAssertClassesHaveTestsRejectsNonExistentDirectory()
     {
         $directory = __DIR__ . '/../Fixture/NonExistentDirectory';
@@ -387,6 +402,25 @@ final class HelperTest extends Framework\TestCase
         );
     }
 
+    public function testAssertClassesHaveTestsWithExcludeClassNamesIgnoresNonExistentExcludeClassNames()
+    {
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests';
+        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\';
+        $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
+        $excludeClassNames = [
+            Fixture\ClassesHaveTests\NotAllClassesHaveTests\AnotherExampleClass::class,
+            Fixture\ClassesHaveTests\NotAllClassesHaveTests\OneMoreExampleClass::class,
+            __NAMESPACE__ . '\\NonExistentClass',
+        ];
+
+        $this->assertClassesHaveTests(
+            $directory,
+            $namespace,
+            $testNamespace,
+            $excludeClassNames
+        );
+    }
+
     public function testAssertClassesSatisfySpecificationRejectsNonExistentDirectory()
     {
         $directory = __DIR__ . '/../Fixture/NonExistentDirectory';
@@ -509,6 +543,23 @@ final class HelperTest extends Framework\TestCase
         $directory = __DIR__ . '/../Fixture/ClassesSatisfySpecification';
         $excludeClassNames = [
             Fixture\ClassesSatisfySpecification\AnotherExampleClass::class,
+        ];
+
+        $this->assertClassesSatisfySpecification(
+            function (string $className) {
+                return Fixture\ClassesSatisfySpecification\ExampleClass::class === $className;
+            },
+            $directory,
+            $excludeClassNames
+        );
+    }
+
+    public function testAssertClassesSatisfySpecificationWithExcludeClassNamesIgnoresNonExistentExcludeClassNames()
+    {
+        $directory = __DIR__ . '/../Fixture/ClassesSatisfySpecification';
+        $excludeClassNames = [
+            Fixture\ClassesSatisfySpecification\AnotherExampleClass::class,
+            __NAMESPACE__ . '\\NonExistentClass',
         ];
 
         $this->assertClassesSatisfySpecification(


### PR DESCRIPTION
This PR

* [x] asserts that non-existent exclude classes are ignored 
* [x] ignores non-existent exclude classes

Blocks https://github.com/localheinz/factory-girl-definition/pull/15.