### PR TITLE
Fix: Increase version requirement for fzaninotto/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "php": "^7.0",
-    "fzaninotto/faker": "^1.0.0",
+    "fzaninotto/faker": "^1.7.1",
     "zendframework/zend-file": "^2.7.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7809cc5e3c12cdf3902a36d20a18c48",
+    "content-hash": "4bf69413054d5cb150f53fee26477538",
     "packages": [
         {
             "name": "fzaninotto/faker",


### PR DESCRIPTION
This PR

* [x] increases the version requirement for `fzaninotto/faker` 

💁‍♂️ There's no reason not to use the latest versions.