### PR TITLE
Fix: Use key when yielding data in data providers

### DIFF
--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -595,8 +595,8 @@ final class HelperTest extends Framework\TestCase
             'trait' => Fixture\NotClass\ExampleTrait::class,
         ];
 
-        foreach ($classNames as $className) {
-            yield [
+        foreach ($classNames as $key => $className) {
+            yield $key => [
                 $className,
             ];
         }


### PR DESCRIPTION
This PR

* [x] consistently uses a key when yielding data in data providers