### PR TITLE
Enhancement: Allow to assert that a class is final

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ the `Helper` trait provides the following assertions:
 * `assertClassExtends(string $parentClassName, string $className)`
 * `assertClassImplementsInterface(string $interfaceName, string $className)`
 * `assertClassIsAbstractOrFinal(string $className)`
+* `assertClassIsFinal(string $className)`
 * `assertClassSatisfiesSpecification(callable $specification, string $className, string $message = '')`
 * `assertClassUsesTrait(string $traitName, string $className)`
 * `assertClassyConstructsSatisfySpecification(callable $specification, string $directory, array $excludeClassNames = [], $message = '')`

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -245,6 +245,25 @@ trait Helper
     }
 
     /**
+     * Asserts that a class is final.
+     *
+     * Useful to prevent long inheritance chains.
+     *
+     * @param string $className
+     */
+    final protected function assertClassIsFinal(string $className)
+    {
+        $this->assertClassExists($className);
+
+        $reflection = new \ReflectionClass($className);
+
+        $this->assertTrue($reflection->isFinal(), \sprintf(
+            'Failed to assert that class "%s" is final.',
+            $className
+        ));
+    }
+
+    /**
      * Asserts that a class satisfies a specification.
      *
      * The specification will be invoked with a single argument, the class name, and should return true or false.

--- a/test/Fixture/ClassIsFinal/AbstractClass.php
+++ b/test/Fixture/ClassIsFinal/AbstractClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
+
+abstract class AbstractClass
+{
+}

--- a/test/Fixture/ClassIsFinal/FinalClass.php
+++ b/test/Fixture/ClassIsFinal/FinalClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
+
+final class FinalClass
+{
+}

--- a/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
+
+class NeitherAbstractNorFinalClass
+{
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -809,6 +809,42 @@ final class HelperTest extends Framework\TestCase
      *
      * @param string $className
      */
+    public function testAssertClassIsFinalFailsWhenClassIsNotClass(string $className)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that a class "%s" exists.',
+            $className
+        ));
+
+        $this->assertClassIsFinal($className);
+    }
+
+    public function testAssertClassIsFinalFailsWhenClassIsNotFinal()
+    {
+        $className = Fixture\ClassIsFinal\NeitherAbstractNorFinalClass::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that class "%s" is final.',
+            $className
+        ));
+
+        $this->assertClassIsFinal($className);
+    }
+
+    public function testAssertClassIsFinalSucceedsWhenClassIsFinal()
+    {
+        $className = Fixture\ClassIsFinal\FinalClass::class;
+
+        $this->assertClassIsFinal($className);
+    }
+
+    /**
+     * @dataProvider providerNotClass
+     *
+     * @param string $className
+     */
     public function testAssertClassSatisfiesSpecificationFailsWhenClassIsNotAClass(string $className)
     {
         $this->expectException(Framework\AssertionFailedError::class);

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -41,6 +41,7 @@ final class ProjectCodeTest extends Framework\TestCase
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\AlsoNeitherAbstractNorFinal::class,
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\NeitherAbstractNorFinal::class,
             Fixture\ClassIsAbstractOrFinal\NeitherAbstractNorFinalClass::class,
+            Fixture\ClassIsFinal\NeitherAbstractNorFinalClass::class,
         ]);
     }
 }


### PR DESCRIPTION
This PR

* [x] allows to assert that a class is `final`

Follows #6.