### PR TITLE
Fix: Consistently use if instead of when

### DIFF
--- a/test/Unit/Constraint/ClassExistsTest.php
+++ b/test/Unit/Constraint/ClassExistsTest.php
@@ -59,7 +59,7 @@ final class ClassExistsTest extends AbstractTestCase
      *
      * @param string $other
      */
-    public function testEvaluateThrowsAssertionFailedErrorWithDefaultMessageWhenClassDoesNotExist(string $other)
+    public function testEvaluateThrowsAssertionFailedErrorWithDefaultMessageIfClassDoesNotExist(string $other)
     {
         $constraint = new ClassExists();
 
@@ -83,7 +83,7 @@ TXT;
      *
      * @param string $other
      */
-    public function testEvaluateThrowsAssertionFailedErrorWithCustomMessageWhenClassDoesNotExist(string $other)
+    public function testEvaluateThrowsAssertionFailedErrorWithCustomMessageIfClassDoesNotExist(string $other)
     {
         $customMessage = $this->faker()->sentence();
 
@@ -105,7 +105,7 @@ TXT;
         $this->fail();
     }
 
-    public function testEvaluateReturnsNullWhenClassExists()
+    public function testEvaluateReturnsNullIfClassExists()
     {
         $other = Fixture\ClassExists\ExampleClass::class;
 

--- a/test/Unit/Constraint/InterfaceExistsTest.php
+++ b/test/Unit/Constraint/InterfaceExistsTest.php
@@ -59,7 +59,7 @@ final class InterfaceExistsTest extends AbstractTestCase
      *
      * @param string $other
      */
-    public function testEvaluateThrowsAssertionFailedErrorWithDefaultMessageWhenInterfaceDoesNotExist(string $other)
+    public function testEvaluateThrowsAssertionFailedErrorWithDefaultMessageIfInterfaceDoesNotExist(string $other)
     {
         $constraint = new InterfaceExists();
 
@@ -83,7 +83,7 @@ TXT;
      *
      * @param string $other
      */
-    public function testEvaluateThrowsAssertionFailedErrorWithCustomMessageWhenInterfaceDoesNotExist(string $other)
+    public function testEvaluateThrowsAssertionFailedErrorWithCustomMessageIfInterfaceDoesNotExist(string $other)
     {
         $customMessage = $this->faker()->sentence();
 
@@ -105,7 +105,7 @@ TXT;
         $this->fail();
     }
 
-    public function testEvaluateReturnsNullWhenInterfaceExists()
+    public function testEvaluateReturnsNullIfInterfaceExists()
     {
         $other = Fixture\InterfaceExists\ExampleInterface::class;
 

--- a/test/Unit/Constraint/TraitExistsTest.php
+++ b/test/Unit/Constraint/TraitExistsTest.php
@@ -59,7 +59,7 @@ final class TraitExistsTest extends AbstractTestCase
      *
      * @param string $other
      */
-    public function testEvaluateThrowsAssertionFailedErrorWithDefaultMessageWhenTraitDoesNotExist(string $other)
+    public function testEvaluateThrowsAssertionFailedErrorWithDefaultMessageIfTraitDoesNotExist(string $other)
     {
         $constraint = new TraitExists();
 
@@ -83,7 +83,7 @@ TXT;
      *
      * @param string $other
      */
-    public function testEvaluateThrowsAssertionFailedErrorWithCustomMessageWhenTraitDoesNotExist(string $other)
+    public function testEvaluateThrowsAssertionFailedErrorWithCustomMessageIfTraitDoesNotExist(string $other)
     {
         $customMessage = $this->faker()->sentence();
 
@@ -105,7 +105,7 @@ TXT;
         $this->fail();
     }
 
-    public function testEvaluateReturnsNullWhenTraitExists()
+    public function testEvaluateReturnsNullIfTraitExists()
     {
         $other = Fixture\TraitExists\ExampleTrait::class;
 


### PR DESCRIPTION
This PR

* [x] consistently uses *if* instead of *when* in test method names

Related to #48.