### PR TITLE
Enhancement: Allow to assert that a class is abstract

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ the `Helper` trait provides the following assertions:
 * `assertClassExists(string $className)`
 * `assertClassExtends(string $parentClassName, string $className)`
 * `assertClassImplementsInterface(string $interfaceName, string $className)`
+* `assertClassIsAbstract(string $className)`
 * `assertClassIsAbstractOrFinal(string $className)`
 * `assertClassIsFinal(string $className)`
 * `assertClassSatisfiesSpecification(callable $specification, string $className, string $message = '')`

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -268,6 +268,23 @@ trait Helper
     }
 
     /**
+     * Asserts that a class is abstract.
+     *
+     * @param string $className
+     */
+    final protected function assertClassIsAbstract(string $className)
+    {
+        $this->assertClassExists($className);
+
+        $reflection = new \ReflectionClass($className);
+
+        $this->assertTrue($reflection->isAbstract(), \sprintf(
+            'Failed asserting that class "%s" is abstract.',
+            $className
+        ));
+    }
+
+    /**
      * Asserts that a class is abstract or final.
      *
      * Useful to prevent long inheritance chains.

--- a/test/Fixture/ClassIsAbstract/AbstractClass.php
+++ b/test/Fixture/ClassIsAbstract/AbstractClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassIsAbstract;
+
+abstract class AbstractClass
+{
+}

--- a/test/Fixture/ClassIsAbstract/ConcreteClass.php
+++ b/test/Fixture/ClassIsAbstract/ConcreteClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassIsAbstract;
+
+class ConcreteClass
+{
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -773,6 +773,42 @@ final class HelperTest extends Framework\TestCase
      *
      * @param string $className
      */
+    public function testAssertClassIsAbstractFailsWhenClassIsNotClass(string $className)
+    {
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed asserting that a class "%s" exists.',
+            $className
+        ));
+
+        $this->assertClassIsAbstract($className);
+    }
+
+    public function testAssertClassIsAbstractFailsWhenClassIsNotAbstract()
+    {
+        $className = Fixture\ClassIsAbstract\ConcreteClass::class;
+
+        $this->expectException(Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed asserting that class "%s" is abstract.',
+            $className
+        ));
+
+        $this->assertClassIsAbstract($className);
+    }
+
+    public function testAssertClassIsAbstractSucceedsWhenClassIsAbstract()
+    {
+        $className = Fixture\ClassIsAbstract\AbstractClass::class;
+
+        $this->assertClassIsAbstract($className);
+    }
+
+    /**
+     * @dataProvider providerNotClass
+     *
+     * @param string $className
+     */
     public function testAssertClassIsAbstractOrFinalFailsWhenClassIsNotClass(string $className)
     {
         $this->expectException(Framework\AssertionFailedError::class);

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -40,6 +40,7 @@ final class ProjectCodeTest extends Framework\TestCase
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..', [
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\AlsoNeitherAbstractNorFinal::class,
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\NeitherAbstractNorFinal::class,
+            Fixture\ClassIsAbstract\ConcreteClass::class,
             Fixture\ClassIsAbstractOrFinal\NeitherAbstractNorFinalClass::class,
             Fixture\ClassIsFinal\NeitherAbstractNorFinalClass::class,
         ]);


### PR DESCRIPTION
This PR

* [x] allows to assert that a class is `abstract`

Follows #6.