### PR TITLE
Fix: Remove reference to non-existent class

### DIFF
--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -41,7 +41,6 @@ final class ProjectCodeTest extends Framework\TestCase
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\AlsoNeitherAbstractNorFinal::class,
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\NeitherAbstractNorFinal::class,
             Fixture\ClassIsAbstract\ConcreteClass::class,
-            Fixture\ClassIsAbstractOrFinal\NeitherAbstractNorFinalClass::class,
             Fixture\ClassIsFinal\NeitherAbstractNorFinalClass::class,
         ]);
     }


### PR DESCRIPTION
This PR

* [x] removes a reference to a non-existent class

Follows #58.