### PR TITLE
Fix: Use mixin annotation to indicate that TestCase is mixed in

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -18,6 +18,9 @@ use Faker\Generator;
 use Localheinz\Classy;
 use PHPUnit\Framework;
 
+/**
+ * @mixin \PHPUnit\Framework\TestCase
+ */
 trait Helper
 {
     /**


### PR DESCRIPTION
This PR

* [x] uses the `@mixin` annotation on the `Helper` to indicate that `PHPUnit\Framework\TestCase` is mixed in

💁‍♂️ For reference, see https://youtrack.jetbrains.com/issue/WI-1730.