### PR TITLE
Fix: Remove irrelevant target from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: composer coverage cs database it test
+.PHONY: composer coverage cs it test
 
 it: cs test
 


### PR DESCRIPTION
This PR

* [x] removes an irrelevant target from `Makefile`