### PR TITLE
Enhancement: Throw NonExistentExcludeClass exception

### DIFF
--- a/src/Exception/NonExistentExcludeClass.php
+++ b/src/Exception/NonExistentExcludeClass.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Exception;
+
+/**
+ * @internal
+ */
+final class NonExistentExcludeClass extends \InvalidArgumentException
+{
+    public static function fromClassName(string $className): self
+    {
+        return new self(\sprintf(
+            'Exclude class "%s" does not exist.',
+            $className
+        ));
+    }
+}

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -86,6 +86,7 @@ trait Helper
      * @param string[] $excludeClassyNames
      *
      * @throws \InvalidArgumentException
+     * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
     final protected function assertClassesHaveTests(string $directory, string $namespace, string $testNamespace, array $excludeClassyNames = [])
@@ -106,10 +107,7 @@ trait Helper
             }
 
             if (!\class_exists($excludeClassyName)) {
-                throw new \InvalidArgumentException(\sprintf(
-                    'Exclude classy names need to be specified as an array of existing classes, but "%s" does not exist.',
-                    $excludeClassyName
-                ));
+                throw Exception\NonExistentExcludeClass::fromClassName($excludeClassyName);
             }
         });
 
@@ -187,6 +185,7 @@ trait Helper
      * @param string   $message
      *
      * @throws \InvalidArgumentException
+     * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
     final protected function assertClassyConstructsSatisfySpecification(callable $specification, string $directory, array $excludeClassyNames = [], string $message = '')
@@ -207,10 +206,7 @@ trait Helper
             }
 
             if (!\class_exists($excludeClassyName)) {
-                throw new \InvalidArgumentException(\sprintf(
-                    'Exclude classy names need to be specified as an array of existing classes, but "%s" does not exist.',
-                    $excludeClassyName
-                ));
+                throw Exception\NonExistentExcludeClass::fromClassName($excludeClassyName);
             }
         });
 

--- a/test/Unit/Exception/NonExistentExcludeClassTest.php
+++ b/test/Unit/Exception/NonExistentExcludeClassTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Exception;
+
+use Localheinz\Test\Util\Exception\NonExistentExcludeClass;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+final class NonExistentExcludeClassTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testExtendsInvalidArgumentException()
+    {
+        $this->assertClassExtends(\InvalidArgumentException::class, NonExistentExcludeClass::class);
+    }
+
+    public function testFromClassNameReturnsException()
+    {
+        $className = \sprintf(
+            '%s\\%s',
+            __NAMESPACE__,
+            $this->faker()->word
+        );
+
+        $exception = NonExistentExcludeClass::fromClassName($className);
+
+        $this->assertInstanceOf(NonExistentExcludeClass::class, $exception);
+        $this->assertSame(0, $exception->getCode());
+
+        $message = \sprintf(
+            'Exclude class "%s" does not exist.',
+            $className
+        );
+
+        $this->assertSame($message, $exception->getMessage());
+    }
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -16,6 +16,7 @@ namespace Localheinz\Test\Util\Test\Unit;
 use Faker\Factory;
 use Faker\Generator;
 use Faker\Provider;
+use Localheinz\Test\Util\Exception;
 use Localheinz\Test\Util\Helper;
 use Localheinz\Test\Util\Test\Fixture;
 use PHPUnit\Framework;
@@ -204,11 +205,7 @@ final class HelperTest extends Framework\TestCase
             $nonExistentClassName,
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(\sprintf(
-            'Exclude classy names need to be specified as an array of existing classes, but "%s" does not exist.',
-            $nonExistentClassName
-        ));
+        $this->expectException(Exception\NonExistentExcludeClass::class);
 
         $this->assertClassesAreAbstractOrFinal(
             $directory,
@@ -417,11 +414,7 @@ final class HelperTest extends Framework\TestCase
             $nonExistentClassName,
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(\sprintf(
-            'Exclude classy names need to be specified as an array of existing classes, but "%s" does not exist.',
-            $nonExistentClassName
-        ));
+        $this->expectException(Exception\NonExistentExcludeClass::class);
 
         $this->assertClassesHaveTests(
             $directory,
@@ -576,11 +569,7 @@ final class HelperTest extends Framework\TestCase
             $nonExistentClassName,
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(\sprintf(
-            'Exclude classy names need to be specified as an array of existing classes, but "%s" does not exist.',
-            $nonExistentClassName
-        ));
+        $this->expectException(Exception\NonExistentExcludeClass::class);
 
         $this->assertClassyConstructsSatisfySpecification(
             function (string $classyName) {


### PR DESCRIPTION
This PR

* [x] implements and throws a `NonExistentExcludeClass` exception if an exclude class does not exist