### PR TITLE
Fix: Add missing throws annotation

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -59,6 +59,7 @@ trait Helper
      *
      * @throws \InvalidArgumentException
      * @throws Exception\NonExistentDirectory
+     * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
     final protected function assertClassesAreAbstractOrFinal(string $directory, array $excludeClassNames = [])


### PR DESCRIPTION
This PR

* [x] adds a missing `@throws` annotation

Follows #68.