### PR TITLE
Enhancement: Throw InvalidExcludeClassName exception

### DIFF
--- a/src/Exception/InvalidExcludeClassName.php
+++ b/src/Exception/InvalidExcludeClassName.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Exception;
+
+/**
+ * @internal
+ */
+final class InvalidExcludeClassName extends \InvalidArgumentException
+{
+    /**
+     * @param mixed $className
+     *
+     * @return self
+     */
+    public static function fromClassName($className): self
+    {
+        return new self(\sprintf(
+            'Exclude class name should be a string, got "%s" instead.',
+            \is_object($className) ? \get_class($className) : \gettype($className)
+        ));
+    }
+}

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -57,8 +57,8 @@ trait Helper
      * @param string   $directory
      * @param string[] $excludeClassNames
      *
-     * @throws \InvalidArgumentException
      * @throws Exception\NonExistentDirectory
+     * @throws Exception\InvalidExcludeClassName
      * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
@@ -87,8 +87,8 @@ trait Helper
      * @param string   $testNamespace
      * @param string[] $excludeClassyNames
      *
-     * @throws \InvalidArgumentException
      * @throws Exception\NonExistentDirectory
+     * @throws Exception\InvalidExcludeClassName
      * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
@@ -100,10 +100,7 @@ trait Helper
 
         \array_walk($excludeClassyNames, function ($excludeClassyName) {
             if (!\is_string($excludeClassyName)) {
-                throw new \InvalidArgumentException(\sprintf(
-                    'Exclude classy names need to be specified as an array of strings, got "%s" instead.',
-                    \is_object($excludeClassyName) ? \get_class($excludeClassyName) : \gettype($excludeClassyName)
-                ));
+                throw Exception\InvalidExcludeClassName::fromClassName($excludeClassyName);
             }
 
             if (!\class_exists($excludeClassyName)) {
@@ -184,8 +181,8 @@ trait Helper
      * @param string[] $excludeClassyNames
      * @param string   $message
      *
-     * @throws \InvalidArgumentException
      * @throws Exception\NonExistentDirectory
+     * @throws Exception\InvalidExcludeClassName
      * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
@@ -197,10 +194,7 @@ trait Helper
 
         \array_walk($excludeClassyNames, function ($excludeClassyName) {
             if (!\is_string($excludeClassyName)) {
-                throw new \InvalidArgumentException(\sprintf(
-                    'Exclude classy names need to be specified as an array of strings, got "%s" instead.',
-                    \is_object($excludeClassyName) ? \get_class($excludeClassyName) : \gettype($excludeClassyName)
-                ));
+                throw Exception\InvalidExcludeClassName::fromClassName($excludeClassyName);
             }
 
             if (!\class_exists($excludeClassyName)) {

--- a/test/Unit/Exception/InvalidExcludeClassNameTest.php
+++ b/test/Unit/Exception/InvalidExcludeClassNameTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Unit\Exception;
+
+use Localheinz\Test\Util\Exception\InvalidExcludeClassName;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+final class InvalidExcludeClassNameTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testExtendsInvalidArgumentException()
+    {
+        $this->assertClassExtends(\InvalidArgumentException::class, InvalidExcludeClassName::class);
+    }
+
+    /**
+     * @dataProvider providerInvalidClassName
+     *
+     * @param mixed $className
+     */
+    public function testFromClassNameReturnsException($className)
+    {
+        $exception = InvalidExcludeClassName::fromClassName($className);
+
+        $this->assertInstanceOf(InvalidExcludeClassName::class, $exception);
+        $this->assertSame(0, $exception->getCode());
+
+        $message = \sprintf(
+            'Exclude class name should be a string, got "%s" instead.',
+            \is_object($className) ? \get_class($className) : \gettype($className)
+        );
+
+        $this->assertSame($message, $exception->getMessage());
+    }
+
+    public function providerInvalidClassName(): \Generator
+    {
+        $className = [
+            'array' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+            'boolean-false' => false,
+            'boolean-true' => true,
+            'float' => 3.14,
+            'integer' => 9000,
+            'null' => null,
+            'object' => new \stdClass(),
+            'resource' => \fopen(__FILE__, 'rb'),
+        ];
+
+        foreach ($className as $key => $classyName) {
+            yield $key => [
+                $classyName,
+            ];
+        }
+    }
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -155,11 +155,7 @@ final class HelperTest extends Framework\TestCase
             $excludeClassName,
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(\sprintf(
-            'Exclude classy names need to be specified as an array of strings, got "%s" instead.',
-            \is_object($excludeClassName) ? \get_class($excludeClassName) : \gettype($excludeClassName)
-        ));
+        $this->expectException(Exception\InvalidExcludeClassName::class);
 
         $this->assertClassesAreAbstractOrFinal(
             $directory,
@@ -380,11 +376,7 @@ final class HelperTest extends Framework\TestCase
             $excludeClassyName,
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(\sprintf(
-            'Exclude classy names need to be specified as an array of strings, got "%s" instead.',
-            \is_object($excludeClassyName) ? \get_class($excludeClassyName) : \gettype($excludeClassyName)
-        ));
+        $this->expectException(Exception\InvalidExcludeClassName::class);
 
         $this->assertClassesHaveTests(
             $directory,
@@ -533,11 +525,7 @@ final class HelperTest extends Framework\TestCase
             $excludeClassyName,
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(\sprintf(
-            'Exclude classy names need to be specified as an array of strings, got "%s" instead.',
-            \is_object($excludeClassyName) ? \get_class($excludeClassyName) : \gettype($excludeClassyName)
-        ));
+        $this->expectException(Exception\InvalidExcludeClassName::class);
 
         $this->assertClassyConstructsSatisfySpecification(
             function (string $classyName) {


### PR DESCRIPTION
This PR

* [x] throws an `InvalidExcludeClassName` exception if an exclude class name is invalid