### PR TITLE
Fix: Remove mixin annotation

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -18,9 +18,6 @@ use Faker\Generator;
 use Localheinz\Classy;
 use PHPUnit\Framework;
 
-/**
- * @mixin \PHPUnit\Framework\TestCase
- */
 trait Helper
 {
     /**


### PR DESCRIPTION
This PR

* [x] removes the `@mixin` annotation

Reverts #61.