### PR TITLE
Fix: Test fixture directories

### DIFF
--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
-final class OneMoreExampleClass
+final class AnotherExampleClass
 {
 }

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
 final class ExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
-abstract class AbstractClass
+final class OneMoreExampleClass
 {
 }

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
-final class AnotherExampleClass
+abstract class AbstractClass
 {
 }

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
-trait ExampleTrait
+final class ExampleClass
 {
 }

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
-abstract class AbstractClass
+interface ExampleInterface
 {
 }

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
-final class ExampleClass
+trait ExampleTrait
 {
 }

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
-trait ExampleTrait
+abstract class AbstractClass
 {
 }

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
-interface ExampleInterface
+final class ExampleClass
 {
 }

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 interface ExampleInterface
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/localheinz/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests;
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
-final class ExampleClass
+trait ExampleTrait
 {
 }

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -259,12 +259,12 @@ final class HelperTest extends Framework\TestCase
 
     public function testAssertClassesHaveTestsFailsWhenFoundClassesDoNotHaveTests()
     {
-        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithoutTests';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithoutTests\\';
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithoutTests/Src';
+        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithoutTests\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithoutTests\\Test\\';
 
         $classesWithoutTests = [
-            Fixture\ClassesHaveTests\WithoutTests\ExampleClass::class,
+            Fixture\ClassesHaveTests\WithoutTests\Src\ExampleClass::class,
         ];
 
         $this->expectException(Framework\AssertionFailedError::class);
@@ -299,8 +299,8 @@ final class HelperTest extends Framework\TestCase
 
     public function testAssertClassesHaveTestsSucceedsWhenNoClassesHaveBeenFound()
     {
-        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/EmptyDirectory';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\';
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/EmptyDirectory/Src';
+        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\Test\\';
 
         $this->assertClassesHaveTests(
@@ -312,8 +312,8 @@ final class HelperTest extends Framework\TestCase
 
     public function testAssertClassesHaveTestsSucceedsWhenFoundClassesHaveTests()
     {
-        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithTests';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\';
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithTests/Src';
+        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Test\\';
 
         $this->assertClassesHaveTests(
@@ -331,7 +331,7 @@ final class HelperTest extends Framework\TestCase
      */
     public function testAssertClassesHaveTestsWorksWithAndWithoutTrailingSlash(string $namespace, string $testNamespace)
     {
-        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithTests';
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithTests/Src';
 
         $this->assertClassesHaveTests(
             $directory,
@@ -343,8 +343,8 @@ final class HelperTest extends Framework\TestCase
     public function providerNamespaceAndTestNamespace(): \Generator
     {
         $namespaces = [
-            'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests',
-            'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\',
+            'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src',
+            'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src\\',
         ];
 
         $testNamespaces = [
@@ -369,8 +369,8 @@ final class HelperTest extends Framework\TestCase
      */
     public function testAssertClassesHaveTestsWithExcludeClassNamesRejectsInvalidExcludeClassNames($excludeClassyName)
     {
-        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\';
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src';
+        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
         $excludeClassyNames = [
             $excludeClassyName,
@@ -388,13 +388,13 @@ final class HelperTest extends Framework\TestCase
 
     public function testAssertClassesHaveTestsWithExcludeClassNamesRejectsNonExistentExcludeClassNames()
     {
-        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\';
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src';
+        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
         $nonExistentClassName = __NAMESPACE__ . '\\NonExistentClass';
         $excludeClassyNames = [
-            Fixture\ClassesHaveTests\NotAllClassesHaveTests\AnotherExampleClass::class,
-            Fixture\ClassesHaveTests\NotAllClassesHaveTests\OneMoreExampleClass::class,
+            Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\AnotherExampleClass::class,
+            Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\OneMoreExampleClass::class,
             $nonExistentClassName,
         ];
 
@@ -410,15 +410,15 @@ final class HelperTest extends Framework\TestCase
 
     public function testAssertClassesHaveTestsWithExcludeClassNamesFailsWhenFoundClassesDoNotHaveTests()
     {
-        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\';
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src';
+        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
         $excludeClassyNames = [
-            Fixture\ClassesHaveTests\NotAllClassesHaveTests\AnotherExampleClass::class,
+            Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\AnotherExampleClass::class,
         ];
 
         $classesWithoutTests = [
-            Fixture\ClassesHaveTests\NotAllClassesHaveTests\OneMoreExampleClass::class,
+            Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\OneMoreExampleClass::class,
         ];
 
         $this->expectException(Framework\AssertionFailedError::class);
@@ -437,12 +437,12 @@ final class HelperTest extends Framework\TestCase
 
     public function testAssertClassesHaveTestsWithExcludeClassNamesSucceedsWhenFoundClassesHaveTests()
     {
-        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\';
+        $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src';
+        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
         $excludeClassyNames = [
-            Fixture\ClassesHaveTests\NotAllClassesHaveTests\AnotherExampleClass::class,
-            Fixture\ClassesHaveTests\NotAllClassesHaveTests\OneMoreExampleClass::class,
+            Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\AnotherExampleClass::class,
+            Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\OneMoreExampleClass::class,
         ];
 
         $this->assertClassesHaveTests(


### PR DESCRIPTION
This PR

* [x] adjusts the directory structure for test fixtures for asserting that classes have tests

💁‍♂️ While there are projects that have their test classes within the same namespace as their production classes, I usually don't.
