### PR TITLE
Fix: Test classes need to be concrete and extend from PHPUnit\Framework\TestCase

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -150,7 +150,7 @@ trait Helper
         });
 
         $this->assertEmpty($classesWithoutTests, \sprintf(
-            "Failed asserting that the classes\n\n%s\n\nhave tests. Expected corresponding test classes\n\n%s\n\nbut could not find them.",
+            "Failed asserting that the classes\n\n%s\n\nhave tests. Expected corresponding test classes\n\n%s\n\nextending from \"%s\" but could not find them.",
             \implode("\n", \array_map(function (string $className) {
                 return \sprintf(
                     ' - %s',
@@ -162,7 +162,8 @@ trait Helper
                     ' - %s',
                     $testClassNameFrom($className)
                 );
-            }, $classesWithoutTests))
+            }, $classesWithoutTests)),
+            Framework\TestCase::class
         ));
     }
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -142,7 +142,7 @@ trait Helper
 
             $testReflection = new \ReflectionClass($testClassName);
 
-            return $testReflection->isSubclassOf(Framework\TestCase::class);
+            return $testReflection->isSubclassOf(Framework\TestCase::class) && $testReflection->isInstantiable();
         };
 
         $classesWithoutTests = \array_filter($classyNames, function (string $className) use ($specification) {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+
+final class AnotherExampleClass
+{
+}

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+
+final class OneMoreExampleClass
+{
+}

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
+
+/**
+ * Does not extend from PHPUnit\Framework\TestCase.
+ */
+final class AnotherExampleClassTest
+{
+}

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
+
+use PHPUnit\Framework;
+
+/**
+ * Extends from PHPUnit\Framework\TestCase, but is abstract.
+ */
+abstract class OneMoreExampleClassTest extends Framework\TestCase
+{
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -264,12 +264,14 @@ final class HelperTest extends Framework\TestCase
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithoutTests\\Test\\';
 
         $classesWithoutTests = [
+            Fixture\ClassesHaveTests\WithoutTests\Src\AnotherExampleClass::class,
             Fixture\ClassesHaveTests\WithoutTests\Src\ExampleClass::class,
+            Fixture\ClassesHaveTests\WithoutTests\Src\OneMoreExampleClass::class,
         ];
 
         $this->expectException(Framework\AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            "Failed asserting that the classes\n\n%s\n\nhave tests. Expected corresponding test classes\n\n%s\n\nbut could not find them.",
+            "Failed asserting that the classes\n\n%s\n\nhave tests. Expected corresponding test classes\n\n%s\n\nextending from \"%s\" but could not find them.",
             \implode("\n", \array_map(function (string $className) {
                 return \sprintf(
                     ' - %s',
@@ -287,7 +289,8 @@ final class HelperTest extends Framework\TestCase
                     ' - %s',
                     $testClassName
                 );
-            }, $classesWithoutTests))
+            }, $classesWithoutTests)),
+            Framework\TestCase::class
         ));
 
         $this->assertClassesHaveTests(


### PR DESCRIPTION
This PR

* [x] asserts that `assertClassesHaveTests()` fails when found test classes are neither concrete nor extend from `PHPUnit\Framework\TestCase`
* [x] adjusts the specification to ensure test classes extend from `PHPUnit\Framework\TestCase` and are instantiable