### PR TITLE
Enhancement: Assert that concrete class with private constructor needs a test

### DIFF
--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/test-util
+ */
+
+namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+
+final class YetAnotherExampleClass
+{
+    private function __construct()
+    {
+    }
+}

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -267,6 +267,7 @@ final class HelperTest extends Framework\TestCase
             Fixture\ClassesHaveTests\WithoutTests\Src\AnotherExampleClass::class,
             Fixture\ClassesHaveTests\WithoutTests\Src\ExampleClass::class,
             Fixture\ClassesHaveTests\WithoutTests\Src\OneMoreExampleClass::class,
+            Fixture\ClassesHaveTests\WithoutTests\Src\YetAnotherExampleClass::class,
         ];
 
         $this->expectException(Framework\AssertionFailedError::class);


### PR DESCRIPTION
This PR

* [x] adds a test case to prevent a regression for concrete class with `private` constructor