### PR TITLE
Fix: Make order of stages on Travis explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 stages:
   - style
   - test
+  - infection
 
 jobs:
   include:


### PR DESCRIPTION
This PR

* [x] makes the order of stages on Travis explicit