### PR TITLE
Enhancement: Run 'composer normalize'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
         - mkdir -p $HOME/.php-cs-fixer
 
       script:
+        - composer normalize --dry-run
         - vendor/bin/php-cs-fixer fix --config=.php_cs --diff --dry-run --verbose
 
     - stage: Stan

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
       php: 7.1
 
       before_install:
+        - composer self-update 1.6.5
         - source .travis/xdebug.sh
         - xdebug-disable
         - composer validate
@@ -44,6 +45,7 @@ jobs:
       php: 7.1
 
       before_install:
+        - composer self-update 1.6.5
         - source .travis/xdebug.sh
         - xdebug-disable
         - composer validate
@@ -64,6 +66,7 @@ jobs:
       env: WITH_LOWEST=true
 
       before_install:
+        - composer self-update 1.6.5
         - source .travis/xdebug.sh
         - xdebug-disable
         - composer validate
@@ -119,6 +122,7 @@ jobs:
       php: 7.2
 
       before_install:
+        - composer self-update 1.6.5
         - source .travis/xdebug.sh
         - xdebug-disable
         - composer validate

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: vendor
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
 
 vendor: composer.json composer.lock
-	composer self-update
+	composer self-update 1.6.5
 	composer validate
 	composer install
 	composer normalize

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,4 @@ vendor: composer.json composer.lock
 	composer self-update
 	composer validate
 	composer install
+	composer normalize

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
   },
   "require-dev": {
     "infection/infection": "~0.8.2",
+    "localheinz/composer-normalize": "~0.8.0",
     "localheinz/php-cs-fixer-config": "~1.14.0",
     "phpstan/phpstan": "~0.9.2",
     "phpstan/phpstan-phpunit": "~0.9.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5918076097c742693d0ba61a2061ea62",
+    "content-hash": "09da0f2aa26305af71da9069b7934078",
     "packages": [
         {
             "name": "fzaninotto/faker",
@@ -643,6 +643,230 @@
                 "versions"
             ],
             "time": "2018-06-13T13:22:40+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "8560d4314577199ba51bf2032f02cd1315587c23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/8560d4314577199ba51bf2032f02cd1315587c23",
+                "reference": "8560d4314577199ba51bf2032f02cd1315587c23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "time": "2018-02-14T22:26:30+00:00"
+        },
+        {
+            "name": "localheinz/composer-normalize",
+            "version": "0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/composer-normalize.git",
+                "reference": "5dd2a43de32fa45d982326d271a12b0b1ea5e6be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/composer-normalize/zipball/5dd2a43de32fa45d982326d271a12b0b1ea5e6be",
+                "reference": "5dd2a43de32fa45d982326d271a12b0b1ea5e6be",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0",
+                "localheinz/json-normalizer": "0.6.0",
+                "php": "^7.1",
+                "sebastian/diff": "^2.0.1 || ^3.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.1.0",
+                "infection/infection": "^0.8.1",
+                "localheinz/php-cs-fixer-config": "~1.13.1",
+                "localheinz/test-util": "0.6.1",
+                "mikey179/vfsstream": "^1.6.5",
+                "phpstan/phpstan": "~0.9.2",
+                "phpunit/phpunit": "^7.1.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Localheinz\\Composer\\Normalize\\NormalizePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\Composer\\Normalize\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a composer plugin for normalizing composer.json.",
+            "homepage": "https://github.com/localheinz/composer-normalize",
+            "keywords": [
+                "composer",
+                "normalize",
+                "normalizer",
+                "plugin"
+            ],
+            "time": "2018-04-24T13:26:04+00:00"
+        },
+        {
+            "name": "localheinz/json-normalizer",
+            "version": "0.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/json-normalizer.git",
+                "reference": "f280f0b8125c7c26b2f8047fa84bfe14de785d84"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/json-normalizer/zipball/f280f0b8125c7c26b2f8047fa84bfe14de785d84",
+                "reference": "f280f0b8125c7c26b2f8047fa84bfe14de785d84",
+                "shasum": ""
+            },
+            "require": {
+                "justinrainbow/json-schema": "^4.0.0 || ^5.0.0",
+                "localheinz/json-printer": "^2.0.0",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "infection/infection": "~0.8.1",
+                "localheinz/php-cs-fixer-config": "~1.13.1",
+                "localheinz/test-util": "0.6.1",
+                "phpbench/phpbench": "~0.14.0",
+                "phpspec/prophecy": "^1.7.1",
+                "phpunit/phpunit": "^7.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\Json\\Normalizer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides normalizers for normalizing JSON documents.",
+            "homepage": "https://github.com/localheinz/json-normalizer",
+            "keywords": [
+                "json",
+                "normalizer"
+            ],
+            "time": "2018-04-07T08:03:24+00:00"
+        },
+        {
+            "name": "localheinz/json-printer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/json-printer.git",
+                "reference": "1a350fd94544df716d1c75ef107d34057f80ac7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/json-printer/zipball/1a350fd94544df716d1c75ef107d34057f80ac7a",
+                "reference": "1a350fd94544df716d1c75ef107d34057f80ac7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "infection/infection": "~0.8.1",
+                "localheinz/php-cs-fixer-config": "~1.13.1",
+                "localheinz/test-util": "0.6.1",
+                "phpbench/phpbench": "~0.14.0",
+                "phpunit/phpunit": "^6.5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\Json\\Printer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a JSON printer, allowing for flexible indentation.",
+            "homepage": "https://github.com/localheinz/json-printer",
+            "keywords": [
+                "formatter",
+                "json",
+                "printer"
+            ],
+            "time": "2018-04-06T22:10:47+00:00"
         },
         {
             "name": "localheinz/php-cs-fixer-config",


### PR DESCRIPTION
This PR

* [x] requires `localheinz/composer-normalize`
* [x] runs `composer normalize` in `vendor` target and on Travis CI
* [x] updates `composer` itself to latest snapshot (see https://github.com/composer/composer/issues/7516#issuecomment-410459001)