### PR TITLE
Fix: Use latest version of composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ jobs:
       php: 7.1
 
       before_install:
-        - composer self-update 1.6.5
         - source .travis/xdebug.sh
         - xdebug-disable
         - composer validate
@@ -45,7 +44,6 @@ jobs:
       php: 7.1
 
       before_install:
-        - composer self-update 1.6.5
         - source .travis/xdebug.sh
         - xdebug-disable
         - composer validate
@@ -66,7 +64,6 @@ jobs:
       env: WITH_LOWEST=true
 
       before_install:
-        - composer self-update 1.6.5
         - source .travis/xdebug.sh
         - xdebug-disable
         - composer validate
@@ -122,7 +119,6 @@ jobs:
       php: 7.2
 
       before_install:
-        - composer self-update 1.6.5
         - source .travis/xdebug.sh
         - xdebug-disable
         - composer validate

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: vendor
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
 
 vendor: composer.json composer.lock
-	composer self-update 1.6.5
+	composer self-update
 	composer validate
 	composer install
 	composer normalize


### PR DESCRIPTION
This PR

* [x] uses the latest version of `composer` again

Follows #94.

💁‍♂️ For reference, see https://github.com/composer/composer/compare/1.7.0...1.7.1.