### PR TITLE
Fix: Disallow installation of phpunit/phpunit:7.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "phpstan/phpstan": "~0.9.2",
     "phpstan/phpstan-phpunit": "~0.9.4",
     "phpstan/phpstan-strict-rules": "~0.9.0",
-    "phpunit/phpunit": "^6.0.0 || ^7.0.0"
+    "phpunit/phpunit": "^6.0.0 || ^7.0.0,<7.4.1"
   },
   "config": {
     "preferred-install": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09da0f2aa26305af71da9069b7934078",
+    "content-hash": "85b14d152b0c20e02b7490d2850a4685",
     "packages": [
         {
             "name": "fzaninotto/faker",
@@ -2507,16 +2507,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.8",
+            "version": "6.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b"
+                "reference": "093ca5508174cd8ab8efe44fd1dde447adfdec8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
-                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/093ca5508174cd8ab8efe44fd1dde447adfdec8f",
+                "reference": "093ca5508174cd8ab8efe44fd1dde447adfdec8f",
                 "shasum": ""
             },
             "require": {
@@ -2587,7 +2587,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-10T11:38:34+00:00"
+            "time": "2018-07-03T06:40:40+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",


### PR DESCRIPTION
This PR

* [x] disallows installation of `phpunit/phpunit:7.4.1`

Related to https://github.com/sebastianbergmann/phpunit/issues/3354.