### PR TITLE
Fix: Let it target depend on stan

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,6 +28,18 @@ $ make cs
 
 to automatically fix coding standard violations.
 
+## Static Code Analysis
+
+We are using [`phpstan/phpstan`](https://github.com/phpstan/phpstan) to statically analyze the code.
+
+Run
+
+```
+$ make stan
+```
+
+to run a static code analysis.
+
 ## Mutation Testing
 
 We are using [`infection/infection`](https://github.com/infection/infection) to ensure a minimum quality of the tests.
@@ -48,4 +60,4 @@ Run
 $ make
 ```
 
-to run both coding standards check and tests!
+to enforce coding standards, perform a static code analysis, and run tests!

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: coverage cs infection it stan test
 
-it: cs test
+it: cs stan test
 
 coverage: vendor
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-text


### PR DESCRIPTION
This PR

* [x] lets the `it` target depend on `stan`