### PR TITLE
Enhancement: Require localheinz/phpstan-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "infection/infection": "~0.11.2",
     "localheinz/composer-normalize": "^1.0.0",
     "localheinz/php-cs-fixer-config": "~1.17.0",
+    "localheinz/phpstan-rules": "~0.3.0",
     "phpstan/phpstan": "~0.10.5",
     "phpstan/phpstan-phpunit": "~0.10.0",
     "phpstan/phpstan-strict-rules": "~0.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4216d3617cf5233419f11eb22f3e2e75",
+    "content-hash": "ad956f81075c43ae95a5e0b1635909b5",
     "packages": [
         {
             "name": "fzaninotto/faker",
@@ -1133,6 +1133,58 @@
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
             "time": "2018-11-27T07:03:30+00:00"
+        },
+        {
+            "name": "localheinz/phpstan-rules",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/phpstan-rules.git",
+                "reference": "e73d0627cc05d2606d8dba6b05b9df184cc6ad1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/phpstan-rules/zipball/e73d0627cc05d2606d8dba6b05b9df184cc6ad1e",
+                "reference": "e73d0627cc05d2606d8dba6b05b9df184cc6ad1e",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.1.0",
+                "php": "^7.1",
+                "phpstan/phpstan": "~0.10.5"
+            },
+            "require-dev": {
+                "infection/infection": "~0.11.1",
+                "localheinz/composer-normalize": "^1.0.0",
+                "localheinz/php-cs-fixer-config": "~1.16.1",
+                "localheinz/test-util": "~0.7.0",
+                "phpstan/phpstan-strict-rules": "~0.10.1",
+                "phpunit/phpunit": "^7.4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\PHPStan\\Rules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides additional rules for phpstan/phpstan.",
+            "homepage": "https://github.com/localheinz/phpstan-rules",
+            "keywords": [
+                "PHPStan",
+                "phpstan-extreme-rules",
+                "phpstan-rules"
+            ],
+            "time": "2018-11-25T10:14:39+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,6 @@ includes:
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 
 parameters:
+	excludes_analyse:
+		- %currentWorkingDirectory%/test/Fixture/
 	tmpDir: %currentWorkingDirectory%/.phpstan

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,8 @@
 includes:
-	- vendor/phpstan/phpstan/conf/config.levelmax.neon
+	- vendor/localheinz/phpstan-rules/rules.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
+	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 
 parameters:
 	tmpDir: %currentWorkingDirectory%/.phpstan

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -1294,15 +1294,21 @@ final class HelperTest extends Framework\TestCase
             return \get_class($provider);
         }, $faker->getProviders());
 
-        $providerLocales = \array_map(static function (string $providerClass): ?string {
-            if (0 === \preg_match('/^Faker\\\\Provider\\\\(?P<locale>[a-z]{2}_[A-Z]{2})\\\\/', $providerClass, $matches)) {
-                return null;
-            }
+        $providerLocales = \array_reduce(
+            $providerClasses,
+            static function (array $providerLocales, string $providerClass): array {
+                if (0 === \preg_match('/^Faker\\\\Provider\\\\(?P<locale>[a-z]{2}_[A-Z]{2})\\\\/', $providerClass, $matches)) {
+                    return $providerLocales;
+                }
 
-            return $matches['locale'];
-        }, $providerClasses);
+                $providerLocales[] = $matches['locale'];
 
-        $locales = \array_values(\array_unique(\array_filter($providerLocales)));
+                return $providerLocales;
+            },
+            []
+        );
+
+        $locales = \array_values(\array_unique($providerLocales));
 
         $expected = [
             $locale,


### PR DESCRIPTION
This PR

* [x] requires `localheinz/phpstan-rules`
* [x] includes `rules.neon` from `localheinz/phpstan-rules`
* [x] excludes fixtures from analysis
* [x] fixes issues