### PR TITLE
Enhancement: Update localheinz/php-cs-fixer-config

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -3,13 +3,14 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
  * @see https://github.com/localheinz/test-util
  */
+
 use Localheinz\PhpCsFixer\Config;
 
 $header = <<<'EOF'

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ jobs:
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:
-        - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer remove --dev localheinz/php-cs-fixer-config; fi
         - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; fi
         - if [[ "$WITH_LOCKED" == "true" ]]; then composer install; fi
         - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require-dev": {
     "infection/infection": "~0.11.4",
     "localheinz/composer-normalize": "^1.0.0",
-    "localheinz/php-cs-fixer-config": "~1.17.0",
+    "localheinz/php-cs-fixer-config": "~1.19.0",
     "localheinz/phpstan-rules": "~0.5.0",
     "phpstan/phpstan": "~0.10.5",
     "phpstan/phpstan-phpunit": "~0.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1f93ac50341705ed663edc2ddc9d5cd",
+    "content-hash": "1ff00a6c6ee37098cb7d38ca38760b2c",
     "packages": [
         {
             "name": "fzaninotto/faker",
@@ -581,16 +581,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.13.1",
+            "version": "v2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161"
+                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/54814c62d5beef3ba55297b9b3186ed8b8a1b161",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b788ea0af899cedc8114dca7db119c93b6685da2",
+                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2",
                 "shasum": ""
             },
             "require": {
@@ -599,7 +599,7 @@
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || >=7.0 <7.3",
+                "php": "^5.6 || ^7.0",
                 "php-cs-fixer/diff": "^1.3",
                 "symfony/console": "^3.4.17 || ^4.1.6",
                 "symfony/event-dispatcher": "^3.0 || ^4.0",
@@ -617,7 +617,7 @@
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.1",
+                "keradus/cli-executor": "^1.2",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.1",
                 "php-cs-fixer/accessible-object": "^1.0",
@@ -637,6 +637,11 @@
                 "php-cs-fixer"
             ],
             "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.14-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -668,7 +673,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-10-21T00:32:10+00:00"
+            "time": "2019-01-04T18:29:47+00:00"
         },
         {
             "name": "infection/infection",
@@ -1095,20 +1100,20 @@
         },
         {
             "name": "localheinz/php-cs-fixer-config",
-            "version": "1.17.0",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/php-cs-fixer-config.git",
-                "reference": "d4835786b5e949ebaf76d29fc8b5b6237ee1e115"
+                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/d4835786b5e949ebaf76d29fc8b5b6237ee1e115",
-                "reference": "d4835786b5e949ebaf76d29fc8b5b6237ee1e115",
+                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/6237bcf8636243bc2d1a995f67c49ac58cb76188",
+                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "^2.13.1",
+                "friendsofphp/php-cs-fixer": "^2.14.0",
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
@@ -1132,7 +1137,7 @@
             ],
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-            "time": "2018-11-27T07:03:30+00:00"
+            "time": "2019-01-04T23:09:58+00:00"
         },
         {
             "name": "localheinz/phpstan-rules",
@@ -3834,20 +3839,21 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "8b93ce06506d58485893e2da366767dcc5390862"
+                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8b93ce06506d58485893e2da366767dcc5390862",
-                "reference": "8b93ce06506d58485893e2da366767dcc5390862",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/921f49c3158a276d27c0d770a5a347a3b718b328",
+                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
@@ -3866,7 +3872,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3893,7 +3899,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-26T10:26:29+00:00"
+            "time": "2018-12-01T08:52:38+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -3996,16 +4002,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "31e5523373cb06163079ef46d0a2d507d70fe064"
+                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/31e5523373cb06163079ef46d0a2d507d70fe064",
-                "reference": "31e5523373cb06163079ef46d0a2d507d70fe064",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
+                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
                 "shasum": ""
             },
             "require": {
@@ -4014,7 +4020,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4046,7 +4052,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4330,25 +4336,26 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "87a801786adb053576dc025892e01fedde9b4fc7"
+                "reference": "ec076716412274e51f8a7ea675d9515e5c311123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/87a801786adb053576dc025892e01fedde9b4fc7",
-                "reference": "87a801786adb053576dc025892e01fedde9b4fc7",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/ec076716412274e51f8a7ea675d9515e5c311123",
+                "reference": "ec076716412274e51f8a7ea675d9515e5c311123",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4375,7 +4382,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/Exception/InvalidExcludeClassName.php
+++ b/src/Exception/InvalidExcludeClassName.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/NonExistentDirectory.php
+++ b/src/Exception/NonExistentDirectory.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/NonExistentExcludeClass.php
+++ b/src/Exception/NonExistentExcludeClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -196,7 +196,7 @@ trait Helper
             throw Exception\NonExistentDirectory::fromDirectory($directory);
         }
 
-        \array_walk($excludeClassyNames, static function ($excludeClassyName) {
+        \array_walk($excludeClassyNames, static function ($excludeClassyName): void {
             if (!\is_string($excludeClassyName)) {
                 throw Exception\InvalidExcludeClassName::fromClassName($excludeClassyName);
             }

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassExists/ExampleClass.php
+++ b/test/Fixture/ClassExists/ExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassExtends/ChildClass.php
+++ b/test/Fixture/ClassExtends/ChildClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassExtends/ParentClass.php
+++ b/test/Fixture/ClassExtends/ParentClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassExtends/UnrelatedClass.php
+++ b/test/Fixture/ClassExtends/UnrelatedClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassIsAbstract/AbstractClass.php
+++ b/test/Fixture/ClassIsAbstract/AbstractClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassIsAbstract/ConcreteClass.php
+++ b/test/Fixture/ClassIsAbstract/ConcreteClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassIsFinal/AbstractClass.php
+++ b/test/Fixture/ClassIsFinal/AbstractClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassIsFinal/FinalClass.php
+++ b/test/Fixture/ClassIsFinal/FinalClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
+++ b/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassUsesTrait/ClassNotUsingTrait.php
+++ b/test/Fixture/ClassUsesTrait/ClassNotUsingTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassUsesTrait/ClassUsingTrait.php
+++ b/test/Fixture/ClassUsesTrait/ClassUsingTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassUsesTrait/ExampleTrait.php
+++ b/test/Fixture/ClassUsesTrait/ExampleTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/AbstractClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/FinalClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesAreAbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/FinalClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AbstractClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AlsoNeitherAbstractNorFinal.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AlsoNeitherAbstractNorFinal.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/FinalClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/NeitherAbstractNorFinal.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/NeitherAbstractNorFinal.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Test/ExampleClassTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassyConstructsSatisfySpecification/AnotherExampleClass.php
+++ b/test/Fixture/ClassyConstructsSatisfySpecification/AnotherExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ClassyConstructsSatisfySpecification/ExampleClass.php
+++ b/test/Fixture/ClassyConstructsSatisfySpecification/ExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ImplementsInterface/ClassImplementingInterface.php
+++ b/test/Fixture/ImplementsInterface/ClassImplementingInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ImplementsInterface/ClassNotImplementingInterface.php
+++ b/test/Fixture/ImplementsInterface/ClassNotImplementingInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/ImplementsInterface/ExampleInterface.php
+++ b/test/Fixture/ImplementsInterface/ExampleInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/InterfaceExists/ExampleInterface.php
+++ b/test/Fixture/InterfaceExists/ExampleInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/InterfaceExtends/ChildInterface.php
+++ b/test/Fixture/InterfaceExtends/ChildInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/InterfaceExtends/ParentInterface.php
+++ b/test/Fixture/InterfaceExtends/ParentInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/InterfaceExtends/UnrelatedInterface.php
+++ b/test/Fixture/InterfaceExtends/UnrelatedInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
+++ b/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/NotClass/ExampleInterface.php
+++ b/test/Fixture/NotClass/ExampleInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/NotClass/ExampleTrait.php
+++ b/test/Fixture/NotClass/ExampleTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/NotInterface/ExampleClass.php
+++ b/test/Fixture/NotInterface/ExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/NotInterface/ExampleTrait.php
+++ b/test/Fixture/NotInterface/ExampleTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/NotTrait/ExampleClass.php
+++ b/test/Fixture/NotTrait/ExampleClass.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/NotTrait/ExampleInterface.php
+++ b/test/Fixture/NotTrait/ExampleInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/TraitExists/ExampleTrait.php
+++ b/test/Fixture/TraitExists/ExampleTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
+++ b/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Unit/Exception/InvalidExcludeClassNameTest.php
+++ b/test/Unit/Exception/InvalidExcludeClassNameTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Unit/Exception/NonExistentDirectoryTest.php
+++ b/test/Unit/Exception/NonExistentDirectoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Unit/Exception/NonExistentExcludeClassTest.php
+++ b/test/Unit/Exception/NonExistentExcludeClassTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.


### PR DESCRIPTION
This PR

* [x] updates `localheinz/php-cs-fixer-config` 
* [x] runs `make cs`
* [x] does not remove `localheinz/php-cs-fixer-config` on PHP 7.3

💁‍♂️ For reference, see https://github.com/localheinz/php-cs-fixer-config/compare/1.17.0...1.19.0.