### PR TITLE
Enhancement: Update localheinz/php-cs-fixer-config

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -33,6 +33,7 @@ $config->getFinder()
         '.php-cs-fixer',
         '.phpstan',
         '.travis',
+        'test/Fixture',
     ])
     ->name('.php_cs');
 

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Localheinz\PhpCsFixer\Config;
+
+$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
+    'final_class' => false,
+]);
+
+$config->getFinder()->in(__DIR__ . '/test/Fixture');
+
+$directory = \getenv('TRAVIS') ? \getenv('HOME') : __DIR__;
+
+$config->setCacheFile($directory . '/.php-cs-fixer/.php_cs.fixture.cache');
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ jobs:
       script:
         - composer normalize --dry-run
         - vendor/bin/php-cs-fixer fix --config=.php_cs --diff --dry-run --verbose
+        - vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --dry-run --verbose
 
     - stage: Stan
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ coverage: vendor
 cs: vendor
 	mkdir -p .php-cs-fixer
 	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --verbose
 
 infection: vendor
 	mkdir -p .infection

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require-dev": {
     "infection/infection": "~0.11.4",
     "localheinz/composer-normalize": "^1.0.0",
-    "localheinz/php-cs-fixer-config": "~1.19.0",
+    "localheinz/php-cs-fixer-config": "~1.23.0",
     "localheinz/phpstan-rules": "~0.5.0",
     "phpstan/phpstan": "~0.10.5",
     "phpstan/phpstan-phpunit": "~0.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ff00a6c6ee37098cb7d38ca38760b2c",
+    "content-hash": "c85ab12ce19a2cb2c070af641931daf0",
     "packages": [
         {
             "name": "fzaninotto/faker",
@@ -238,16 +238,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "url": "https://api.github.com/repos/composer/semver/zipball/46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
+                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
                 "shasum": ""
             },
             "require": {
@@ -296,7 +296,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-08-30T16:08:34+00:00"
+            "time": "2019-03-19T17:25:45+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -361,16 +361,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.3.1",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "dc523135366eb68f22268d069ea7749486458562"
+                "reference": "46867cbf8ca9fb8d60c506895449eb799db1184f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/dc523135366eb68f22268d069ea7749486458562",
-                "reference": "dc523135366eb68f22268d069ea7749486458562",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/46867cbf8ca9fb8d60c506895449eb799db1184f",
+                "reference": "46867cbf8ca9fb8d60c506895449eb799db1184f",
                 "shasum": ""
             },
             "require": {
@@ -401,20 +401,20 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-11-29T10:59:02+00:00"
+            "time": "2019-05-27T17:52:04+00:00"
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.6.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
-                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/904dca4eb10715b92569fbcd79e201d5c349b6bc",
+                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc",
                 "shasum": ""
             },
             "require": {
@@ -423,12 +423,12 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -442,16 +442,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -469,7 +469,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-12-06T07:11:42+00:00"
+            "time": "2019-10-01T18:55:10+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -527,20 +527,23 @@
         },
         {
             "name": "doctrine/lexer",
-            "version": "v1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
             },
             "type": "library",
             "extra": {
@@ -549,8 +552,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Lexer\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -571,26 +574,29 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
             "keywords": [
+                "annotations",
+                "docblock",
                 "lexer",
-                "parser"
+                "parser",
+                "php"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
+            "time": "2019-06-08T11:03:04+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.14.0",
+            "version": "v2.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2"
+                "reference": "705490b0f282f21017d73561e9498d2b622ee34c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b788ea0af899cedc8114dca7db119c93b6685da2",
-                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/705490b0f282f21017d73561e9498d2b622ee34c",
+                "reference": "705490b0f282f21017d73561e9498d2b622ee34c",
                 "shasum": ""
             },
             "require": {
@@ -611,9 +617,6 @@
                 "symfony/process": "^3.0 || ^4.0",
                 "symfony/stopwatch": "^3.0 || ^4.0"
             },
-            "conflict": {
-                "hhvm": "*"
-            },
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
@@ -621,11 +624,12 @@
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.1",
                 "php-cs-fixer/accessible-object": "^1.0",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.0.1",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.0.1",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1",
-                "phpunitgoodpractices/traits": "^1.5.1",
-                "symfony/phpunit-bridge": "^4.0"
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
+                "phpunitgoodpractices/traits": "^1.8",
+                "symfony/phpunit-bridge": "^4.3",
+                "symfony/yaml": "^3.0 || ^4.0"
             },
             "suggest": {
                 "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
@@ -637,11 +641,6 @@
                 "php-cs-fixer"
             ],
             "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.14-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -664,16 +663,16 @@
             ],
             "authors": [
                 {
-                    "name": "Dariusz Rumiński",
-                    "email": "dariusz.ruminski@gmail.com"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2019-01-04T18:29:47+00:00"
+            "time": "2019-08-31T12:51:54+00:00"
         },
         {
             "name": "infection/infection",
@@ -1100,24 +1099,25 @@
         },
         {
             "name": "localheinz/php-cs-fixer-config",
-            "version": "1.19.0",
+            "version": "1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/php-cs-fixer-config.git",
-                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188"
+                "reference": "a1ebb34c6a4466115354a01e3f6f491f1e8f867d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/6237bcf8636243bc2d1a995f67c49ac58cb76188",
-                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188",
+                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/a1ebb34c6a4466115354a01e3f6f491f1e8f867d",
+                "reference": "a1ebb34c6a4466115354a01e3f6f491f1e8f867d",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "^2.14.0",
-                "php": "^5.6 || ^7.0"
+                "friendsofphp/php-cs-fixer": "~2.15.2",
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.25"
+                "localheinz/composer-normalize": "^1.3.0",
+                "phpunit/phpunit": "^7.5.15"
             },
             "type": "library",
             "autoload": {
@@ -1137,7 +1137,7 @@
             ],
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-            "time": "2019-01-04T23:09:58+00:00"
+            "time": "2019-08-27T18:08:23+00:00"
         },
         {
             "name": "localheinz/phpstan-rules",
@@ -3702,37 +3702,43 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.2.1",
+            "version": "v4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4dff24e5d01e713818805c1862d2e3f901ee7dd0"
+                "reference": "929ddf360d401b958f611d44e726094ab46a7369"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4dff24e5d01e713818805c1862d2e3f901ee7dd0",
-                "reference": "4dff24e5d01e713818805c1862d2e3f901ee7dd0",
+                "url": "https://api.github.com/repos/symfony/console/zipball/929ddf360d401b958f611d44e726094ab46a7369",
+                "reference": "929ddf360d401b958f611d44e726094ab46a7369",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3",
                 "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0"
+                "symfony/process": "~3.4|~4.0",
+                "symfony/var-dumper": "^4.3"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -3740,7 +3746,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3767,102 +3773,40 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-27T07:40:44+00:00"
-        },
-        {
-            "name": "symfony/contracts",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/contracts.git",
-                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
-                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "require-dev": {
-                "psr/cache": "^1.0",
-                "psr/container": "^1.0"
-            },
-            "suggest": {
-                "psr/cache": "When using the Cache contracts",
-                "psr/container": "When using the Service contracts",
-                "symfony/cache-contracts-implementation": "",
-                "symfony/service-contracts-implementation": "",
-                "symfony/translation-contracts-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\": ""
-                },
-                "exclude-from-classmap": [
-                    "**/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A set of abstractions extracted out of the Symfony components",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2018-12-05T08:06:11+00:00"
+            "time": "2019-10-07T12:36:49+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.2.1",
+            "version": "v4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328"
+                "reference": "6229f58993e5a157f6096fc7145c0717d0be8807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/921f49c3158a276d27c0d770a5a347a3b718b328",
-                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6229f58993e5a157f6096fc7145c0717d0be8807",
+                "reference": "6229f58993e5a157f6096fc7145c0717d0be8807",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0"
+                "symfony/event-dispatcher-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
             },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-foundation": "^3.4|^4.0",
+                "symfony/service-contracts": "^1.1",
                 "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
@@ -3872,7 +3816,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3899,20 +3843,78 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-12-01T08:52:38+00:00"
+            "time": "2019-10-01T16:40:32+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v4.2.1",
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "2f4c8b999b3b7cadb2a69390b01af70886753710"
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2f4c8b999b3b7cadb2a69390b01af70886753710",
-                "reference": "2f4c8b999b3b7cadb2a69390b01af70886753710",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-09-17T09:54:03+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v4.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "9abbb7ef96a51f4d7e69627bc6f63307994e4263"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/9abbb7ef96a51f4d7e69627bc6f63307994e4263",
+                "reference": "9abbb7ef96a51f4d7e69627bc6f63307994e4263",
                 "shasum": ""
             },
             "require": {
@@ -3922,7 +3924,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3949,20 +3951,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:52:12+00:00"
+            "time": "2019-08-20T14:07:54+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.2.1",
+            "version": "v4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e53d477d7b5c4982d0e1bfd2298dbee63d01441d"
+                "reference": "5e575faa95548d0586f6bedaeabec259714e44d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e53d477d7b5c4982d0e1bfd2298dbee63d01441d",
-                "reference": "e53d477d7b5c4982d0e1bfd2298dbee63d01441d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/5e575faa95548d0586f6bedaeabec259714e44d1",
+                "reference": "5e575faa95548d0586f6bedaeabec259714e44d1",
                 "shasum": ""
             },
             "require": {
@@ -3971,7 +3973,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3998,20 +4000,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:52:12+00:00"
+            "time": "2019-09-16T11:29:48+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.2.1",
+            "version": "v4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba"
+                "reference": "81c2e120522a42f623233968244baebd6b36cb6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
-                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/81c2e120522a42f623233968244baebd6b36cb6a",
+                "reference": "81c2e120522a42f623233968244baebd6b36cb6a",
                 "shasum": ""
             },
             "require": {
@@ -4020,7 +4022,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -4052,20 +4054,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-11-11T19:52:12+00:00"
+            "time": "2019-08-08T09:29:19+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -4077,7 +4079,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -4094,12 +4096,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -4110,20 +4112,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.10.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
                 "shasum": ""
             },
             "require": {
@@ -4135,7 +4137,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -4169,20 +4171,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.10.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224"
+                "reference": "54b4c428a0054e254223797d2713c31e08610831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6b88000cdd431cd2e940caa2cb569201f3f84224",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/54b4c428a0054e254223797d2713c31e08610831",
+                "reference": "54b4c428a0054e254223797d2713c31e08610831",
                 "shasum": ""
             },
             "require": {
@@ -4192,7 +4194,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -4228,20 +4230,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T06:26:08+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.10.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631"
+                "reference": "04ce3335667451138df4307d6a9b61565560199e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
-                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/04ce3335667451138df4307d6a9b61565560199e",
+                "reference": "04ce3335667451138df4307d6a9b61565560199e",
                 "shasum": ""
             },
             "require": {
@@ -4250,7 +4252,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -4283,20 +4285,78 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v4.2.1",
+            "name": "symfony/polyfill-php73",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "2b341009ccec76837a7f46f59641b431e4d4c2b0"
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/2b341009ccec76837a7f46f59641b431e4d4c2b0",
-                "reference": "2b341009ccec76837a7f46f59641b431e4d4c2b0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "50556892f3cc47d4200bfd1075314139c4c9ff4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/50556892f3cc47d4200bfd1075314139c4c9ff4b",
+                "reference": "50556892f3cc47d4200bfd1075314139c4c9ff4b",
                 "shasum": ""
             },
             "require": {
@@ -4305,7 +4365,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -4332,30 +4392,88 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-20T16:22:05+00:00"
+            "time": "2019-09-26T21:17:10+00:00"
         },
         {
-            "name": "symfony/stopwatch",
-            "version": "v4.2.1",
+            "name": "symfony/service-contracts",
+            "version": "v1.1.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "ec076716412274e51f8a7ea675d9515e5c311123"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "ffcde9615dc5bb4825b9f6aed07716f1f57faae0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/ec076716412274e51f8a7ea675d9515e5c311123",
-                "reference": "ec076716412274e51f8a7ea675d9515e5c311123",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffcde9615dc5bb4825b9f6aed07716f1f57faae0",
+                "reference": "ffcde9615dc5bb4825b9f6aed07716f1f57faae0",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0"
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-09-17T11:12:18+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v4.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "1e4ff456bd625be5032fac9be4294e60442e9b71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/1e4ff456bd625be5032fac9be4294e60442e9b71",
+                "reference": "1e4ff456bd625be5032fac9be4294e60442e9b71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/service-contracts": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -4382,7 +4500,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:52:12+00:00"
+            "time": "2019-08-07T11:52:19+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 final class SrcCodeTest extends Framework\TestCase

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class SrcCodeTest extends Framework\TestCase
 {

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class TestCodeTest extends Framework\TestCase
 {

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 final class TestCodeTest extends Framework\TestCase

--- a/test/Fixture/ClassExists/ExampleClass.php
+++ b/test/Fixture/ClassExists/ExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassExists;
 

--- a/test/Fixture/ClassExists/ExampleClass.php
+++ b/test/Fixture/ClassExists/ExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassExists;
 
 final class ExampleClass

--- a/test/Fixture/ClassExtends/ChildClass.php
+++ b/test/Fixture/ClassExtends/ChildClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
 

--- a/test/Fixture/ClassExtends/ChildClass.php
+++ b/test/Fixture/ClassExtends/ChildClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
 
 final class ChildClass extends ParentClass

--- a/test/Fixture/ClassExtends/ParentClass.php
+++ b/test/Fixture/ClassExtends/ParentClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
 

--- a/test/Fixture/ClassExtends/ParentClass.php
+++ b/test/Fixture/ClassExtends/ParentClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
 
 abstract class ParentClass

--- a/test/Fixture/ClassExtends/UnrelatedClass.php
+++ b/test/Fixture/ClassExtends/UnrelatedClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
 
 final class UnrelatedClass

--- a/test/Fixture/ClassExtends/UnrelatedClass.php
+++ b/test/Fixture/ClassExtends/UnrelatedClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
 

--- a/test/Fixture/ClassIsAbstract/AbstractClass.php
+++ b/test/Fixture/ClassIsAbstract/AbstractClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsAbstract;
 

--- a/test/Fixture/ClassIsAbstract/AbstractClass.php
+++ b/test/Fixture/ClassIsAbstract/AbstractClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsAbstract;
 
 abstract class AbstractClass

--- a/test/Fixture/ClassIsAbstract/ConcreteClass.php
+++ b/test/Fixture/ClassIsAbstract/ConcreteClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsAbstract;
 

--- a/test/Fixture/ClassIsAbstract/ConcreteClass.php
+++ b/test/Fixture/ClassIsAbstract/ConcreteClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsAbstract;
 
 class ConcreteClass

--- a/test/Fixture/ClassIsFinal/AbstractClass.php
+++ b/test/Fixture/ClassIsFinal/AbstractClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
 
 abstract class AbstractClass

--- a/test/Fixture/ClassIsFinal/AbstractClass.php
+++ b/test/Fixture/ClassIsFinal/AbstractClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
 

--- a/test/Fixture/ClassIsFinal/FinalClass.php
+++ b/test/Fixture/ClassIsFinal/FinalClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
 
 final class FinalClass

--- a/test/Fixture/ClassIsFinal/FinalClass.php
+++ b/test/Fixture/ClassIsFinal/FinalClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
 

--- a/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
 
 class NeitherAbstractNorFinalClass

--- a/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
 

--- a/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
+++ b/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassSatisfiesSpecification;
 
 final class ExampleClass

--- a/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
+++ b/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassSatisfiesSpecification;
 

--- a/test/Fixture/ClassUsesTrait/ClassNotUsingTrait.php
+++ b/test/Fixture/ClassUsesTrait/ClassNotUsingTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
 
 final class ClassNotUsingTrait

--- a/test/Fixture/ClassUsesTrait/ClassNotUsingTrait.php
+++ b/test/Fixture/ClassUsesTrait/ClassNotUsingTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
 

--- a/test/Fixture/ClassUsesTrait/ClassUsingTrait.php
+++ b/test/Fixture/ClassUsesTrait/ClassUsingTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
 

--- a/test/Fixture/ClassUsesTrait/ClassUsingTrait.php
+++ b/test/Fixture/ClassUsesTrait/ClassUsingTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
 
 final class ClassUsingTrait

--- a/test/Fixture/ClassUsesTrait/ExampleTrait.php
+++ b/test/Fixture/ClassUsesTrait/ExampleTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
 
 trait ExampleTrait

--- a/test/Fixture/ClassUsesTrait/ExampleTrait.php
+++ b/test/Fixture/ClassUsesTrait/ExampleTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal;
 
 final class AbstractClass

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/AbstractClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\AbstractOrFinal;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/AbstractClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\AbstractOrFinal;
 
 abstract class AbstractClass

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/FinalClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\AbstractOrFinal;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/FinalClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\AbstractOrFinal;
 
 final class FinalClass

--- a/test/Fixture/ClassesAreAbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/FinalClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/FinalClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal;
 
 final class FinalClass

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AbstractClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AbstractClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 
 abstract class AbstractClass

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AlsoNeitherAbstractNorFinal.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AlsoNeitherAbstractNorFinal.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 
 class AlsoNeitherAbstractNorFinal

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AlsoNeitherAbstractNorFinal.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AlsoNeitherAbstractNorFinal.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/FinalClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/FinalClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 
 final class FinalClass

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/NeitherAbstractNorFinal.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/NeitherAbstractNorFinal.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/NeitherAbstractNorFinal.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/NeitherAbstractNorFinal.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 
 class NeitherAbstractNorFinal

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
 final class AnotherExampleClass

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
 final class ExampleClass

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
 final class OneMoreExampleClass

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Test;
 
 use PHPUnit\Framework;

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 final class ExampleClassTest extends Framework\TestCase

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Test;
 
@@ -17,6 +10,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class ExampleClassTest extends Framework\TestCase
 {

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 abstract class AbstractClass

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 final class ExampleClass

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 interface ExampleInterface

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
@@ -17,6 +10,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class ExampleTest extends Framework\TestCase
 {

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 final class ExampleTest extends Framework\TestCase

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 use PHPUnit\Framework;

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 trait ExampleTrait

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Test/ExampleClassTest.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Test;
 
@@ -17,6 +10,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class ExampleClassTest extends Framework\TestCase
 {

--- a/test/Fixture/ClassesHaveTests/WithTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Test/ExampleClassTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Test;
 
 use PHPUnit\Framework;

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 abstract class AbstractClass

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 final class AnotherExampleClass

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 final class ExampleClass

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 interface ExampleInterface

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 trait ExampleTrait

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 final class OneMoreExampleClass

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 final class YetAnotherExampleClass

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
 
@@ -17,6 +10,7 @@ namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
  * Does not extend from PHPUnit\Framework\TestCase.
  *
  * @internal
+ * @coversNothing
  */
 final class AnotherExampleClassTest
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
@@ -8,6 +8,7 @@ namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
  * Does not extend from PHPUnit\Framework\TestCase.
  *
  * @internal
+ *
  * @coversNothing
  */
 final class AnotherExampleClassTest

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
 
 /**

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
 
 use PHPUnit\Framework;

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
 

--- a/test/Fixture/ClassyConstructsSatisfySpecification/AnotherExampleClass.php
+++ b/test/Fixture/ClassyConstructsSatisfySpecification/AnotherExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassyConstructsSatisfySpecification;
 

--- a/test/Fixture/ClassyConstructsSatisfySpecification/AnotherExampleClass.php
+++ b/test/Fixture/ClassyConstructsSatisfySpecification/AnotherExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassyConstructsSatisfySpecification;
 
 final class AnotherExampleClass

--- a/test/Fixture/ClassyConstructsSatisfySpecification/ExampleClass.php
+++ b/test/Fixture/ClassyConstructsSatisfySpecification/ExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ClassyConstructsSatisfySpecification;
 

--- a/test/Fixture/ClassyConstructsSatisfySpecification/ExampleClass.php
+++ b/test/Fixture/ClassyConstructsSatisfySpecification/ExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ClassyConstructsSatisfySpecification;
 
 final class ExampleClass

--- a/test/Fixture/ImplementsInterface/ClassImplementingInterface.php
+++ b/test/Fixture/ImplementsInterface/ClassImplementingInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
 
 final class ClassImplementingInterface implements ExampleInterface

--- a/test/Fixture/ImplementsInterface/ClassImplementingInterface.php
+++ b/test/Fixture/ImplementsInterface/ClassImplementingInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
 

--- a/test/Fixture/ImplementsInterface/ClassNotImplementingInterface.php
+++ b/test/Fixture/ImplementsInterface/ClassNotImplementingInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
 

--- a/test/Fixture/ImplementsInterface/ClassNotImplementingInterface.php
+++ b/test/Fixture/ImplementsInterface/ClassNotImplementingInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
 
 final class ClassNotImplementingInterface

--- a/test/Fixture/ImplementsInterface/ExampleInterface.php
+++ b/test/Fixture/ImplementsInterface/ExampleInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
 

--- a/test/Fixture/ImplementsInterface/ExampleInterface.php
+++ b/test/Fixture/ImplementsInterface/ExampleInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
 
 interface ExampleInterface

--- a/test/Fixture/InterfaceExists/ExampleInterface.php
+++ b/test/Fixture/InterfaceExists/ExampleInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceExists;
 
 interface ExampleInterface

--- a/test/Fixture/InterfaceExists/ExampleInterface.php
+++ b/test/Fixture/InterfaceExists/ExampleInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceExists;
 

--- a/test/Fixture/InterfaceExtends/ChildInterface.php
+++ b/test/Fixture/InterfaceExtends/ChildInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
 
 interface ChildInterface extends ParentInterface

--- a/test/Fixture/InterfaceExtends/ChildInterface.php
+++ b/test/Fixture/InterfaceExtends/ChildInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
 

--- a/test/Fixture/InterfaceExtends/ParentInterface.php
+++ b/test/Fixture/InterfaceExtends/ParentInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
 
 interface ParentInterface

--- a/test/Fixture/InterfaceExtends/ParentInterface.php
+++ b/test/Fixture/InterfaceExtends/ParentInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
 

--- a/test/Fixture/InterfaceExtends/UnrelatedInterface.php
+++ b/test/Fixture/InterfaceExtends/UnrelatedInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
 
 interface UnrelatedInterface

--- a/test/Fixture/InterfaceExtends/UnrelatedInterface.php
+++ b/test/Fixture/InterfaceExtends/UnrelatedInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
 

--- a/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
+++ b/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceSatisfiesSpecification;
 

--- a/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
+++ b/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\InterfaceSatisfiesSpecification;
 
 interface ExampleInterface

--- a/test/Fixture/NotClass/ExampleInterface.php
+++ b/test/Fixture/NotClass/ExampleInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\NotClass;
 
 interface ExampleInterface

--- a/test/Fixture/NotClass/ExampleInterface.php
+++ b/test/Fixture/NotClass/ExampleInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\NotClass;
 

--- a/test/Fixture/NotClass/ExampleTrait.php
+++ b/test/Fixture/NotClass/ExampleTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\NotClass;
 

--- a/test/Fixture/NotClass/ExampleTrait.php
+++ b/test/Fixture/NotClass/ExampleTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\NotClass;
 
 trait ExampleTrait

--- a/test/Fixture/NotInterface/ExampleClass.php
+++ b/test/Fixture/NotInterface/ExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\NotInterface;
 
 final class ExampleClass

--- a/test/Fixture/NotInterface/ExampleClass.php
+++ b/test/Fixture/NotInterface/ExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\NotInterface;
 

--- a/test/Fixture/NotInterface/ExampleTrait.php
+++ b/test/Fixture/NotInterface/ExampleTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\NotInterface;
 

--- a/test/Fixture/NotInterface/ExampleTrait.php
+++ b/test/Fixture/NotInterface/ExampleTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\NotInterface;
 
 trait ExampleTrait

--- a/test/Fixture/NotTrait/ExampleClass.php
+++ b/test/Fixture/NotTrait/ExampleClass.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\NotTrait;
 

--- a/test/Fixture/NotTrait/ExampleClass.php
+++ b/test/Fixture/NotTrait/ExampleClass.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\NotTrait;
 
 final class ExampleClass

--- a/test/Fixture/NotTrait/ExampleInterface.php
+++ b/test/Fixture/NotTrait/ExampleInterface.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\NotTrait;
 

--- a/test/Fixture/NotTrait/ExampleInterface.php
+++ b/test/Fixture/NotTrait/ExampleInterface.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\NotTrait;
 
 interface ExampleInterface

--- a/test/Fixture/TraitExists/ExampleTrait.php
+++ b/test/Fixture/TraitExists/ExampleTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\TraitExists;
 
 trait ExampleTrait

--- a/test/Fixture/TraitExists/ExampleTrait.php
+++ b/test/Fixture/TraitExists/ExampleTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\TraitExists;
 

--- a/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
+++ b/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
@@ -2,14 +2,7 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2017 Andreas Möller
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/test-util
- */
+
 
 namespace Localheinz\Test\Util\Test\Fixture\TraitSatisfiesSpecification;
 

--- a/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
+++ b/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-
-
 namespace Localheinz\Test\Util\Test\Fixture\TraitSatisfiesSpecification;
 
 trait ExampleTrait

--- a/test/Unit/Exception/InvalidExcludeClassNameTest.php
+++ b/test/Unit/Exception/InvalidExcludeClassNameTest.php
@@ -19,7 +19,8 @@ use PHPUnit\Framework;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\Test\Util\Exception\InvalidExcludeClassName
  */
 final class InvalidExcludeClassNameTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/InvalidExcludeClassNameTest.php
+++ b/test/Unit/Exception/InvalidExcludeClassNameTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework;
  * @internal
  *
  * @covers \Localheinz\Test\Util\Exception\InvalidExcludeClassName
+ *
+ * @uses \Localheinz\Test\Util\Helper
  */
 final class InvalidExcludeClassNameTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/InvalidExcludeClassNameTest.php
+++ b/test/Unit/Exception/InvalidExcludeClassNameTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class InvalidExcludeClassNameTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/NonExistentDirectoryTest.php
+++ b/test/Unit/Exception/NonExistentDirectoryTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NonExistentDirectoryTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/NonExistentDirectoryTest.php
+++ b/test/Unit/Exception/NonExistentDirectoryTest.php
@@ -19,7 +19,8 @@ use PHPUnit\Framework;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\Test\Util\Exception\NonExistentDirectory
  */
 final class NonExistentDirectoryTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/NonExistentDirectoryTest.php
+++ b/test/Unit/Exception/NonExistentDirectoryTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework;
  * @internal
  *
  * @covers \Localheinz\Test\Util\Exception\NonExistentDirectory
+ *
+ * @uses \Localheinz\Test\Util\Helper
  */
 final class NonExistentDirectoryTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/NonExistentExcludeClassTest.php
+++ b/test/Unit/Exception/NonExistentExcludeClassTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NonExistentExcludeClassTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/NonExistentExcludeClassTest.php
+++ b/test/Unit/Exception/NonExistentExcludeClassTest.php
@@ -19,7 +19,8 @@ use PHPUnit\Framework;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\Test\Util\Exception\NonExistentExcludeClass
  */
 final class NonExistentExcludeClassTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/NonExistentExcludeClassTest.php
+++ b/test/Unit/Exception/NonExistentExcludeClassTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework;
  * @internal
  *
  * @covers \Localheinz\Test\Util\Exception\NonExistentExcludeClass
+ *
+ * @uses \Localheinz\Test\Util\Helper
  */
 final class NonExistentExcludeClassTest extends Framework\TestCase
 {

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class HelperTest extends Framework\TestCase
 {
@@ -284,10 +285,10 @@ final class HelperTest extends Framework\TestCase
             }, $classesWithoutTests)),
             \implode("\n", \array_map(static function (string $className) use ($namespace, $testNamespace): string {
                 $testClassName = \str_replace(
-                        $namespace,
-                        $testNamespace,
-                        $className
-                    ) . 'Test';
+                    $namespace,
+                    $testNamespace,
+                    $className
+                ) . 'Test';
 
                 return \sprintf(
                     ' - %s',

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -23,7 +23,8 @@ use PHPUnit\Framework;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\Test\Util\Helper
  */
 final class HelperTest extends Framework\TestCase
 {

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -25,6 +25,10 @@ use PHPUnit\Framework;
  * @internal
  *
  * @covers \Localheinz\Test\Util\Helper
+ *
+ * @uses \Localheinz\Test\Util\Exception\InvalidExcludeClassName
+ * @uses \Localheinz\Test\Util\Exception\NonExistentDirectory
+ * @uses \Localheinz\Test\Util\Exception\NonExistentExcludeClass
  */
 final class HelperTest extends Framework\TestCase
 {

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class ProjectCodeTest extends Framework\TestCase
 {

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 final class ProjectCodeTest extends Framework\TestCase


### PR DESCRIPTION
This PR

* [x] updates `localheinz/php-cs-fixer-config`
* [x] splits the configuration for `php-cs-fixer`
* [x] runs `make cs`
* [x] adjusts `@covers` annotations
* [x] adds missing `@uses` annotations

💁‍♂ For reference, see https://github.com/localheinz/php-cs-fixer-config/compare/1.19.0...1.23.0.