### PR TITLE
Fix: Methods can be static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ For a full diff see [`0.7.0...master`](https://github.com/localheinz/php-library
 ### Changed
 
 * Dropped support for PHP 7.1 ([#118](https://github.com/localheinz/test-util/pull/118)), by [@localheinz](https://github.com/localheinz)
+* Methods in `Helper` trait are now `static` ([#119](https://github.com/localheinz/test-util/pull/119)), by [@localheinz](https://github.com/localheinz)

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -31,7 +31,7 @@ trait Helper
      *
      * @return Generator
      */
-    final protected function faker(string $locale = 'en_US'): Generator
+    final protected static function faker(string $locale = 'en_US'): Generator
     {
         static $fakers = [];
 
@@ -59,9 +59,9 @@ trait Helper
      * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
-    final protected function assertClassesAreAbstractOrFinal(string $directory, array $excludeClassNames = []): void
+    final protected static function assertClassesAreAbstractOrFinal(string $directory, array $excludeClassNames = []): void
     {
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $className): bool {
                 $reflection = new \ReflectionClass($className);
 
@@ -89,7 +89,7 @@ trait Helper
      * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
-    final protected function assertClassesHaveTests(string $directory, string $namespace, string $testNamespace, array $excludeClassyNames = []): void
+    final protected static function assertClassesHaveTests(string $directory, string $namespace, string $testNamespace, array $excludeClassyNames = []): void
     {
         if (!\is_dir($directory)) {
             throw Exception\NonExistentDirectory::fromDirectory($directory);
@@ -190,7 +190,7 @@ trait Helper
      * @throws Exception\NonExistentExcludeClass
      * @throws Classy\Exception\MultipleDefinitionsFound
      */
-    final protected function assertClassyConstructsSatisfySpecification(callable $specification, string $directory, array $excludeClassyNames = [], string $message = ''): void
+    final protected static function assertClassyConstructsSatisfySpecification(callable $specification, string $directory, array $excludeClassyNames = [], string $message = ''): void
     {
         if (!\is_dir($directory)) {
             throw Exception\NonExistentDirectory::fromDirectory($directory);
@@ -228,7 +228,7 @@ trait Helper
      *
      * @param string $className
      */
-    final protected function assertClassExists(string $className): void
+    final protected static function assertClassExists(string $className): void
     {
         self::assertTrue(\class_exists($className), \sprintf(
             'Failed asserting that a class "%s" exists.',
@@ -242,10 +242,10 @@ trait Helper
      * @param string $parentClassName
      * @param string $className
      */
-    final protected function assertClassExtends(string $parentClassName, string $className): void
+    final protected static function assertClassExtends(string $parentClassName, string $className): void
     {
-        $this->assertClassExists($parentClassName);
-        $this->assertClassExists($className);
+        self::assertClassExists($parentClassName);
+        self::assertClassExists($className);
 
         $reflection = new \ReflectionClass($className);
 
@@ -262,10 +262,10 @@ trait Helper
      * @param string $interfaceName
      * @param string $className
      */
-    final protected function assertClassImplementsInterface(string $interfaceName, string $className): void
+    final protected static function assertClassImplementsInterface(string $interfaceName, string $className): void
     {
-        $this->assertInterfaceExists($interfaceName);
-        $this->assertClassExists($className);
+        self::assertInterfaceExists($interfaceName);
+        self::assertClassExists($className);
 
         $reflection = new \ReflectionClass($className);
 
@@ -281,9 +281,9 @@ trait Helper
      *
      * @param string $className
      */
-    final protected function assertClassIsAbstract(string $className): void
+    final protected static function assertClassIsAbstract(string $className): void
     {
-        $this->assertClassExists($className);
+        self::assertClassExists($className);
 
         $reflection = new \ReflectionClass($className);
 
@@ -300,9 +300,9 @@ trait Helper
      *
      * @param string $className
      */
-    final protected function assertClassIsFinal(string $className): void
+    final protected static function assertClassIsFinal(string $className): void
     {
-        $this->assertClassExists($className);
+        self::assertClassExists($className);
 
         $reflection = new \ReflectionClass($className);
 
@@ -321,9 +321,9 @@ trait Helper
      * @param string   $className
      * @param string   $message
      */
-    final protected function assertClassSatisfiesSpecification(callable $specification, string $className, string $message = ''): void
+    final protected static function assertClassSatisfiesSpecification(callable $specification, string $className, string $message = ''): void
     {
-        $this->assertClassExists($className);
+        self::assertClassExists($className);
 
         self::assertTrue($specification($className), \sprintf(
             '' !== $message ? $message : 'Failed asserting that class "%s" satisfies a specification.',
@@ -337,10 +337,10 @@ trait Helper
      * @param string $traitName
      * @param string $className
      */
-    final protected function assertClassUsesTrait(string $traitName, string $className): void
+    final protected static function assertClassUsesTrait(string $traitName, string $className): void
     {
-        $this->assertTraitExists($traitName);
-        $this->assertClassExists($className);
+        self::assertTraitExists($traitName);
+        self::assertClassExists($className);
 
         self::assertContains($traitName, \class_uses($className), \sprintf(
             'Failed asserting that class "%s" uses trait "%s".',
@@ -354,7 +354,7 @@ trait Helper
      *
      * @param string $interfaceName
      */
-    final protected function assertInterfaceExists(string $interfaceName): void
+    final protected static function assertInterfaceExists(string $interfaceName): void
     {
         self::assertTrue(\interface_exists($interfaceName), \sprintf(
             'Failed asserting that an interface "%s" exists.',
@@ -368,10 +368,10 @@ trait Helper
      * @param string $parentInterfaceName
      * @param string $interfaceName
      */
-    final protected function assertInterfaceExtends(string $parentInterfaceName, string $interfaceName): void
+    final protected static function assertInterfaceExtends(string $parentInterfaceName, string $interfaceName): void
     {
-        $this->assertInterfaceExists($parentInterfaceName);
-        $this->assertInterfaceExists($interfaceName);
+        self::assertInterfaceExists($parentInterfaceName);
+        self::assertInterfaceExists($interfaceName);
 
         $reflection = new \ReflectionClass($interfaceName);
 
@@ -391,9 +391,9 @@ trait Helper
      * @param string   $interfaceName
      * @param string   $message
      */
-    final protected function assertInterfaceSatisfiesSpecification(callable $specification, string $interfaceName, string $message = ''): void
+    final protected static function assertInterfaceSatisfiesSpecification(callable $specification, string $interfaceName, string $message = ''): void
     {
-        $this->assertInterfaceExists($interfaceName);
+        self::assertInterfaceExists($interfaceName);
 
         self::assertTrue($specification($interfaceName), \sprintf(
             '' !== $message ? $message : 'Failed asserting that interface "%s" satisfies a specification.',
@@ -406,7 +406,7 @@ trait Helper
      *
      * @param string $traitName
      */
-    final protected function assertTraitExists(string $traitName): void
+    final protected static function assertTraitExists(string $traitName): void
     {
         self::assertTrue(\trait_exists($traitName), \sprintf(
             'Failed asserting that a trait "%s" exists.',
@@ -423,9 +423,9 @@ trait Helper
      * @param string   $traitName
      * @param string   $message
      */
-    final protected function assertTraitSatisfiesSpecification(callable $specification, string $traitName, string $message = ''): void
+    final protected static function assertTraitSatisfiesSpecification(callable $specification, string $traitName, string $message = ''): void
     {
-        $this->assertTraitExists($traitName);
+        self::assertTraitExists($traitName);
 
         self::assertTrue($specification($traitName), \sprintf(
             '' !== $message ? $message : 'Failed asserting that trait "%s" satisfies a specification.',

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -27,12 +27,12 @@ final class SrcCodeTest extends Framework\TestCase
 
     public function testSrcClassesAreAbstractOrFinal(): void
     {
-        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
+        self::assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
     }
 
     public function testSrcClassesHaveTests(): void
     {
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             __DIR__ . '/../../src',
             'Localheinz\\Test\\Util\\',
             'Localheinz\\Test\\Util\\Test\\Unit\\'

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -28,7 +28,7 @@ final class TestCodeTest extends Framework\TestCase
 
     public function testTestClassesAreAbstractOrFinal(): void
     {
-        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..', [
+        self::assertClassesAreAbstractOrFinal(__DIR__ . '/..', [
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\AlsoNeitherAbstractNorFinal::class,
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\NeitherAbstractNorFinal::class,
             Fixture\ClassIsAbstract\ConcreteClass::class,

--- a/test/Unit/Exception/InvalidExcludeClassNameTest.php
+++ b/test/Unit/Exception/InvalidExcludeClassNameTest.php
@@ -30,7 +30,7 @@ final class InvalidExcludeClassNameTest extends Framework\TestCase
 
     public function testExtendsInvalidArgumentException(): void
     {
-        $this->assertClassExtends(\InvalidArgumentException::class, InvalidExcludeClassName::class);
+        self::assertClassExtends(\InvalidArgumentException::class, InvalidExcludeClassName::class);
     }
 
     /**

--- a/test/Unit/Exception/NonExistentDirectoryTest.php
+++ b/test/Unit/Exception/NonExistentDirectoryTest.php
@@ -30,7 +30,7 @@ final class NonExistentDirectoryTest extends Framework\TestCase
 
     public function testExtendsInvalidArgumentException(): void
     {
-        $this->assertClassExtends(\InvalidArgumentException::class, NonExistentDirectory::class);
+        self::assertClassExtends(\InvalidArgumentException::class, NonExistentDirectory::class);
     }
 
     public function testFromDirectoryReturnsException(): void

--- a/test/Unit/Exception/NonExistentExcludeClassTest.php
+++ b/test/Unit/Exception/NonExistentExcludeClassTest.php
@@ -30,7 +30,7 @@ final class NonExistentExcludeClassTest extends Framework\TestCase
 
     public function testExtendsInvalidArgumentException(): void
     {
-        $this->assertClassExtends(\InvalidArgumentException::class, NonExistentExcludeClass::class);
+        self::assertClassExtends(\InvalidArgumentException::class, NonExistentExcludeClass::class);
     }
 
     public function testFromClassNameReturnsException(): void

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -34,7 +34,7 @@ final class HelperTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testHelperMethodsAreFinalAndProtected(): void
+    public function testHelperMethodsAreFinalProtectedAndStatic(): void
     {
         $className = Helper::class;
 
@@ -43,7 +43,7 @@ final class HelperTest extends Framework\TestCase
         $methods = $reflection->getMethods();
 
         $methodsNeitherFinalNorProtected = \array_filter($methods, static function (\ReflectionMethod $method): bool {
-            return !$method->isFinal() || !$method->isProtected();
+            return !$method->isFinal() || !$method->isProtected() || !$method->isStatic();
         });
 
         self::assertEmpty($methodsNeitherFinalNorProtected, \sprintf(
@@ -60,7 +60,7 @@ final class HelperTest extends Framework\TestCase
 
     public function testFakerWithoutLocaleReturnsFakerWithDefaultLocale(): void
     {
-        $faker = $this->faker();
+        $faker = self::faker();
 
         $this->assertHasOnlyProvidersWithLocale(Factory::DEFAULT_LOCALE, $faker);
     }
@@ -72,7 +72,7 @@ final class HelperTest extends Framework\TestCase
      */
     public function testFakerWithLocaleReturnsFakerWithSpecifiedLocale(string $locale): void
     {
-        $faker = $this->faker($locale);
+        $faker = self::faker($locale);
 
         $this->assertHasOnlyProvidersWithLocale($locale, $faker);
     }
@@ -84,9 +84,9 @@ final class HelperTest extends Framework\TestCase
      */
     public function testFakerReturnsSameFaker(string $locale): void
     {
-        $faker = $this->faker($locale);
+        $faker = self::faker($locale);
 
-        self::assertSame($faker, $this->faker($locale));
+        self::assertSame($faker, self::faker($locale));
     }
 
     public function providerLocale(): \Generator
@@ -118,7 +118,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\NonExistentDirectory::class);
 
-        $this->assertClassesAreAbstractOrFinal($directory);
+        self::assertClassesAreAbstractOrFinal($directory);
     }
 
     public function testAssertClassesAreAbstractOrFinalFailsWhenFoundClassesAreNeitherAbstractNorFinal(): void
@@ -135,21 +135,21 @@ final class HelperTest extends Framework\TestCase
             ' - ' . \implode("\n - ", $classesNeitherAbstractNorFinal)
         ));
 
-        $this->assertClassesAreAbstractOrFinal($directory);
+        self::assertClassesAreAbstractOrFinal($directory);
     }
 
     public function testAssertClassesAreAbstractOrFinalSucceedsWhenNoClassesHaveBeenFound(): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesAreAbstractOrFinal/EmptyDirectory';
 
-        $this->assertClassesAreAbstractOrFinal($directory);
+        self::assertClassesAreAbstractOrFinal($directory);
     }
 
     public function testAssertClassesAreAbstractOrFinalSucceedsWhenFoundClassesAreAbstractOrFinal(): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal';
 
-        $this->assertClassesAreAbstractOrFinal($directory);
+        self::assertClassesAreAbstractOrFinal($directory);
     }
 
     /**
@@ -166,7 +166,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\InvalidExcludeClassName::class);
 
-        $this->assertClassesAreAbstractOrFinal(
+        self::assertClassesAreAbstractOrFinal(
             $directory,
             $excludeClassNames
         );
@@ -208,7 +208,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\NonExistentExcludeClass::class);
 
-        $this->assertClassesAreAbstractOrFinal(
+        self::assertClassesAreAbstractOrFinal(
             $directory,
             $excludeClassyNames
         );
@@ -231,7 +231,7 @@ final class HelperTest extends Framework\TestCase
             ' - ' . \implode("\n - ", $classesNeitherAbstractNorFinal)
         ));
 
-        $this->assertClassesAreAbstractOrFinal(
+        self::assertClassesAreAbstractOrFinal(
             $directory,
             $excludeClassyNames
         );
@@ -245,7 +245,7 @@ final class HelperTest extends Framework\TestCase
             Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal\NeitherAbstractNorFinal::class,
         ];
 
-        $this->assertClassesAreAbstractOrFinal(
+        self::assertClassesAreAbstractOrFinal(
             $directory,
             $excludeClassyNames
         );
@@ -259,7 +259,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\NonExistentDirectory::class);
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace
@@ -303,7 +303,7 @@ final class HelperTest extends Framework\TestCase
             Framework\TestCase::class
         ));
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace
@@ -316,7 +316,7 @@ final class HelperTest extends Framework\TestCase
         $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\Test\\';
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace
@@ -329,7 +329,7 @@ final class HelperTest extends Framework\TestCase
         $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src\\';
         $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Test\\';
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace
@@ -346,7 +346,7 @@ final class HelperTest extends Framework\TestCase
     {
         $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithTests/Src';
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace
@@ -391,7 +391,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\InvalidExcludeClassName::class);
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace,
@@ -413,7 +413,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\NonExistentExcludeClass::class);
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace,
@@ -440,7 +440,7 @@ final class HelperTest extends Framework\TestCase
             ' - ' . \implode("\n - ", $classesWithoutTests)
         ));
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace,
@@ -458,7 +458,7 @@ final class HelperTest extends Framework\TestCase
             Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\OneMoreExampleClass::class,
         ];
 
-        $this->assertClassesHaveTests(
+        self::assertClassesHaveTests(
             $directory,
             $namespace,
             $testNamespace,
@@ -472,7 +472,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\NonExistentDirectory::class);
 
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $classyName): bool {
                 return false;
             },
@@ -494,7 +494,7 @@ final class HelperTest extends Framework\TestCase
             ' - ' . \implode("\n - ", $classesNotSatisfyingSpecification)
         ));
 
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $className): bool {
                 return false;
             },
@@ -506,7 +506,7 @@ final class HelperTest extends Framework\TestCase
     {
         $directory = __DIR__ . '/../Fixture/ClassyConstructsSatisfySpecification/EmptyDirectory';
 
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $className): bool {
                 return false;
             },
@@ -518,7 +518,7 @@ final class HelperTest extends Framework\TestCase
     {
         $directory = __DIR__ . '/../Fixture/ClassyConstructsSatisfySpecification';
 
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $className): bool {
                 return true;
             },
@@ -540,7 +540,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\InvalidExcludeClassName::class);
 
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $classyName): bool {
                 return true;
             },
@@ -560,7 +560,7 @@ final class HelperTest extends Framework\TestCase
 
         $this->expectException(Exception\NonExistentExcludeClass::class);
 
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $classyName): bool {
                 return Fixture\ClassyConstructsSatisfySpecification\ExampleClass::class === $classyName;
             },
@@ -586,7 +586,7 @@ final class HelperTest extends Framework\TestCase
             ' - ' . \implode("\n - ", $classesNotSatisfyingSpecification)
         ));
 
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $classyName): bool {
                 return false;
             },
@@ -602,7 +602,7 @@ final class HelperTest extends Framework\TestCase
             Fixture\ClassyConstructsSatisfySpecification\AnotherExampleClass::class,
         ];
 
-        $this->assertClassyConstructsSatisfySpecification(
+        self::assertClassyConstructsSatisfySpecification(
             static function (string $classyName): bool {
                 return Fixture\ClassyConstructsSatisfySpecification\ExampleClass::class === $classyName;
             },
@@ -624,7 +624,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassExists($className);
+        self::assertClassExists($className);
     }
 
     public function providerNotClass(): \Generator
@@ -646,7 +646,7 @@ final class HelperTest extends Framework\TestCase
     {
         $className = Fixture\ClassExists\ExampleClass::class;
 
-        $this->assertClassExists($className);
+        self::assertClassExists($className);
     }
 
     /**
@@ -664,7 +664,7 @@ final class HelperTest extends Framework\TestCase
             $parentClassName
         ));
 
-        $this->assertClassExtends(
+        self::assertClassExtends(
             $parentClassName,
             $className
         );
@@ -685,7 +685,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassExtends(
+        self::assertClassExtends(
             $parentClassName,
             $className
         );
@@ -703,7 +703,7 @@ final class HelperTest extends Framework\TestCase
             $parentClassName
         ));
 
-        $this->assertClassExtends(
+        self::assertClassExtends(
             $parentClassName,
             $className
         );
@@ -714,7 +714,7 @@ final class HelperTest extends Framework\TestCase
         $parentClassName = Fixture\ClassExtends\ParentClass::class;
         $className = Fixture\ClassExtends\ChildClass::class;
 
-        $this->assertClassExtends(
+        self::assertClassExtends(
             $parentClassName,
             $className
         );
@@ -735,7 +735,7 @@ final class HelperTest extends Framework\TestCase
             $interfaceName
         ));
 
-        $this->assertClassImplementsInterface(
+        self::assertClassImplementsInterface(
             $interfaceName,
             $className
         );
@@ -756,7 +756,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassImplementsInterface(
+        self::assertClassImplementsInterface(
             $interfaceName,
             $className
         );
@@ -774,7 +774,7 @@ final class HelperTest extends Framework\TestCase
             $interfaceName
         ));
 
-        $this->assertClassImplementsInterface(
+        self::assertClassImplementsInterface(
             $interfaceName,
             $className
         );
@@ -785,7 +785,7 @@ final class HelperTest extends Framework\TestCase
         $interfaceName = Fixture\ImplementsInterface\ExampleInterface::class;
         $className = Fixture\ImplementsInterface\ClassImplementingInterface::class;
 
-        $this->assertClassImplementsInterface(
+        self::assertClassImplementsInterface(
             $interfaceName,
             $className
         );
@@ -804,7 +804,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassIsAbstract($className);
+        self::assertClassIsAbstract($className);
     }
 
     public function testAssertClassIsAbstractFailsWhenClassIsNotAbstract(): void
@@ -817,14 +817,14 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassIsAbstract($className);
+        self::assertClassIsAbstract($className);
     }
 
     public function testAssertClassIsAbstractSucceedsWhenClassIsAbstract(): void
     {
         $className = Fixture\ClassIsAbstract\AbstractClass::class;
 
-        $this->assertClassIsAbstract($className);
+        self::assertClassIsAbstract($className);
     }
 
     /**
@@ -840,7 +840,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassIsFinal($className);
+        self::assertClassIsFinal($className);
     }
 
     public function testAssertClassIsFinalFailsWhenClassIsNotFinal(): void
@@ -853,14 +853,14 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassIsFinal($className);
+        self::assertClassIsFinal($className);
     }
 
     public function testAssertClassIsFinalSucceedsWhenClassIsFinal(): void
     {
         $className = Fixture\ClassIsFinal\FinalClass::class;
 
-        $this->assertClassIsFinal($className);
+        self::assertClassIsFinal($className);
     }
 
     /**
@@ -876,7 +876,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassSatisfiesSpecification(
+        self::assertClassSatisfiesSpecification(
             static function (): bool {
                 return true;
             },
@@ -894,7 +894,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassSatisfiesSpecification(
+        self::assertClassSatisfiesSpecification(
             static function (): bool {
                 return false;
             },
@@ -913,7 +913,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassSatisfiesSpecification(
+        self::assertClassSatisfiesSpecification(
             static function (): bool {
                 return false;
             },
@@ -926,7 +926,7 @@ final class HelperTest extends Framework\TestCase
     {
         $className = Fixture\ClassSatisfiesSpecification\ExampleClass::class;
 
-        $this->assertClassSatisfiesSpecification(
+        self::assertClassSatisfiesSpecification(
             static function (): bool {
                 return true;
             },
@@ -949,7 +949,7 @@ final class HelperTest extends Framework\TestCase
             $traitName
         ));
 
-        $this->assertClassUsesTrait(
+        self::assertClassUsesTrait(
             $traitName,
             $className
         );
@@ -970,7 +970,7 @@ final class HelperTest extends Framework\TestCase
             $className
         ));
 
-        $this->assertClassUsesTrait(
+        self::assertClassUsesTrait(
             $traitName,
             $className
         );
@@ -988,7 +988,7 @@ final class HelperTest extends Framework\TestCase
             $traitName
         ));
 
-        $this->assertClassUsesTrait(
+        self::assertClassUsesTrait(
             $traitName,
             $className
         );
@@ -999,7 +999,7 @@ final class HelperTest extends Framework\TestCase
         $traitName = Fixture\ClassUsesTrait\ExampleTrait::class;
         $className = Fixture\ClassUsesTrait\ClassUsingTrait::class;
 
-        $this->assertClassUsesTrait(
+        self::assertClassUsesTrait(
             $traitName,
             $className
         );
@@ -1018,7 +1018,7 @@ final class HelperTest extends Framework\TestCase
             $interfaceName
         ));
 
-        $this->assertInterfaceExists($interfaceName);
+        self::assertInterfaceExists($interfaceName);
     }
 
     public function providerNotInterface(): \Generator
@@ -1040,7 +1040,7 @@ final class HelperTest extends Framework\TestCase
     {
         $interfaceName = Fixture\InterfaceExists\ExampleInterface::class;
 
-        $this->assertInterfaceExists($interfaceName);
+        self::assertInterfaceExists($interfaceName);
     }
 
     /**
@@ -1058,7 +1058,7 @@ final class HelperTest extends Framework\TestCase
             $parentInterfaceName
         ));
 
-        $this->assertInterfaceExtends(
+        self::assertInterfaceExtends(
             $parentInterfaceName,
             $interfaceName
         );
@@ -1079,7 +1079,7 @@ final class HelperTest extends Framework\TestCase
             $interfaceName
         ));
 
-        $this->assertInterfaceExtends(
+        self::assertInterfaceExtends(
             $parentInterfaceName,
             $interfaceName
         );
@@ -1097,7 +1097,7 @@ final class HelperTest extends Framework\TestCase
             $parentInterfaceName
         ));
 
-        $this->assertInterfaceExtends(
+        self::assertInterfaceExtends(
             $parentInterfaceName,
             $interfaceName
         );
@@ -1108,7 +1108,7 @@ final class HelperTest extends Framework\TestCase
         $parentInterfaceName = Fixture\InterfaceExtends\ParentInterface::class;
         $interfaceName = Fixture\InterfaceExtends\ChildInterface::class;
 
-        $this->assertInterfaceExtends(
+        self::assertInterfaceExtends(
             $parentInterfaceName,
             $interfaceName
         );
@@ -1127,7 +1127,7 @@ final class HelperTest extends Framework\TestCase
             $interfaceName
         ));
 
-        $this->assertInterfaceSatisfiesSpecification(
+        self::assertInterfaceSatisfiesSpecification(
             static function (): bool {
                 return true;
             },
@@ -1145,7 +1145,7 @@ final class HelperTest extends Framework\TestCase
             $interfaceName
         ));
 
-        $this->assertInterfaceSatisfiesSpecification(
+        self::assertInterfaceSatisfiesSpecification(
             static function (): bool {
                 return false;
             },
@@ -1164,7 +1164,7 @@ final class HelperTest extends Framework\TestCase
             $interfaceName
         ));
 
-        $this->assertInterfaceSatisfiesSpecification(
+        self::assertInterfaceSatisfiesSpecification(
             static function (): bool {
                 return false;
             },
@@ -1177,7 +1177,7 @@ final class HelperTest extends Framework\TestCase
     {
         $interfaceName = Fixture\InterfaceSatisfiesSpecification\ExampleInterface::class;
 
-        $this->assertInterfaceSatisfiesSpecification(
+        self::assertInterfaceSatisfiesSpecification(
             static function (): bool {
                 return true;
             },
@@ -1198,7 +1198,7 @@ final class HelperTest extends Framework\TestCase
             $traitName
         ));
 
-        $this->assertTraitExists($traitName);
+        self::assertTraitExists($traitName);
     }
 
     public function providerNotTrait(): \Generator
@@ -1220,7 +1220,7 @@ final class HelperTest extends Framework\TestCase
     {
         $traitName = Fixture\TraitExists\ExampleTrait::class;
 
-        $this->assertTraitExists($traitName);
+        self::assertTraitExists($traitName);
     }
 
     /**
@@ -1236,7 +1236,7 @@ final class HelperTest extends Framework\TestCase
             $traitName
         ));
 
-        $this->assertTraitSatisfiesSpecification(
+        self::assertTraitSatisfiesSpecification(
             static function (): bool {
                 return true;
             },
@@ -1254,7 +1254,7 @@ final class HelperTest extends Framework\TestCase
             $traitName
         ));
 
-        $this->assertTraitSatisfiesSpecification(
+        self::assertTraitSatisfiesSpecification(
             static function (): bool {
                 return false;
             },
@@ -1273,7 +1273,7 @@ final class HelperTest extends Framework\TestCase
             $traitName
         ));
 
-        $this->assertTraitSatisfiesSpecification(
+        self::assertTraitSatisfiesSpecification(
             static function (): bool {
                 return false;
             },
@@ -1286,7 +1286,7 @@ final class HelperTest extends Framework\TestCase
     {
         $traitName = Fixture\TraitSatisfiesSpecification\ExampleTrait::class;
 
-        $this->assertTraitSatisfiesSpecification(
+        self::assertTraitSatisfiesSpecification(
             static function (): bool {
                 return true;
             },


### PR DESCRIPTION
This PR

* [x] turns instance methods in `Helper` into `static` methods