### PR TITLE
Fix: Exclude phpunit/phpunit from dependabot updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,6 +8,9 @@ update_configs:
     default_reviewers:
       - "localheinz"
     directory: "/"
+    ignored_updates:
+      - match:
+          dependency_name: "phpunit/phpunit"
     package_manager: "php:composer"
     update_schedule: "live"
     version_requirement_updates: "increase_versions"


### PR DESCRIPTION
This PR

* [x] excludes `phpunit/phpunit` from dependabot updates