### PR TITLE
Enhancement: Use ergebnis/classy instead of localheinz/classy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
   ],
   "require": {
     "php": "^7.2",
-    "fzaninotto/faker": "^1.9.0",
-    "localheinz/classy": "0.4.0"
+    "ergebnis/classy": "~0.5.0",
+    "fzaninotto/faker": "^1.9.0"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,59 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a17c0646ef6cd51a0c96f4e6d277c99",
+    "content-hash": "889d3284e1d485e7bbdf8663eafe3c5e",
     "packages": [
+        {
+            "name": "ergebnis/classy",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/classy.git",
+                "reference": "7ba774c203fd1e9b6ab5aad846b500a3d9121fd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/classy/zipball/7ba774c203fd1e9b6ab5aad846b500a3d9121fd9",
+                "reference": "7ba774c203fd1e9b6ab5aad846b500a3d9121fd9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "ergebnis/php-cs-fixer-config": "~1.1.0",
+                "infection/infection": "~0.15.0",
+                "localheinz/composer-normalize": "^1.3.1",
+                "localheinz/phpstan-rules": "~0.13.0",
+                "localheinz/test-util": "0.2.2",
+                "phpbench/phpbench": "~0.16.10",
+                "phpstan/phpstan": "~0.11.19",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^8.4.3",
+                "zendframework/zend-file": "^2.8.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Classy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a way to collect classy constructs from source or a directory.",
+            "homepage": "https://github.com/ergebnis/classy",
+            "time": "2019-12-05T22:45:51+00:00"
+        },
         {
             "name": "fzaninotto/faker",
             "version": "v1.9.0",
@@ -53,55 +104,6 @@
                 "fixtures"
             ],
             "time": "2019-11-14T13:13:06+00:00"
-        },
-        {
-            "name": "localheinz/classy",
-            "version": "0.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/classy.git",
-                "reference": "01ef6ffc263f62379726477e706f77f20f424fdf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/classy/zipball/01ef6ffc263f62379726477e706f77f20f424fdf",
-                "reference": "01ef6ffc263f62379726477e706f77f20f424fdf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "infection/infection": "~0.11.4",
-                "localheinz/composer-normalize": "^1.0.0",
-                "localheinz/php-cs-fixer-config": "~1.17.0",
-                "localheinz/phpstan-rules": "~0.5.0",
-                "localheinz/test-util": "0.2.2",
-                "phpbench/phpbench": "~0.14.0",
-                "phpstan/phpstan": "~0.10.5",
-                "phpstan/phpstan-strict-rules": "~0.10.1",
-                "phpunit/phpunit": "^7.5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\Classy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides a way to collect classy constructs from source or a directory.",
-            "homepage": "https://github.com/localheinz/classy",
-            "abandoned": "ergebnis/classy",
-            "time": "2018-12-10T18:56:43+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Localheinz\Test\Util;
 
+use Ergebnis\Classy;
 use Faker\Factory;
 use Faker\Generator;
-use Localheinz\Classy;
 use PHPUnit\Framework;
 
 trait Helper


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/classy` instead of `localheinz/classy`