### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -83,7 +83,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":eyeglasses: Provides utilities for tests."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 95

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.0...master`][1.0.0...master].
+For a full diff see [`1.0.0...main`][1.0.0...main].
 
 ## [`1.0.0`][1.0.0]
 
@@ -78,7 +78,7 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [0.8.0...0.9.0]: https://github.com/ergebnis/test-util/compare/0.8.0...0.9.0
 [0.9.0...0.9.1]: https://github.com/ergebnis/test-util/compare/0.9.0...0.9.1
 [0.9.1...1.0.0]: https://github.com/ergebnis/test-util/compare/0.9.1...1.0.0
-[1.0.0...master]: https://github.com/ergebnis/test-util/compare/1.0.0...master
+[1.0.0...main]: https://github.com/ergebnis/test-util/compare/1.0.0...main
 
 [#118]: https://github.com/ergebnis/test-util/pull/118
 [#119]: https://github.com/ergebnis/test-util/pull/119

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # test-util
 
-[![Integrate](https://github.com/ergebnis/test-util/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/test-util/actions)
-[![Prune](https://github.com/ergebnis/test-util/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/test-util/actions)
-[![Release](https://github.com/ergebnis/test-util/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/test-util/actions)
-[![Renew](https://github.com/ergebnis/test-util/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/test-util/actions)
+[![Integrate](https://github.com/ergebnis/test-util/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/test-util/actions)
+[![Prune](https://github.com/ergebnis/test-util/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/test-util/actions)
+[![Release](https://github.com/ergebnis/test-util/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/test-util/actions)
+[![Renew](https://github.com/ergebnis/test-util/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/test-util/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/test-util/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/test-util)
+[![Code Coverage](https://codecov.io/gh/ergebnis/test-util/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/test-util)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/test-util/coverage.svg)](https://shepherd.dev/github/ergebnis/test-util)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/test-util/v/stable)](https://packagist.org/packages/ergebnis/test-util)
@@ -105,7 +105,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.