### PR TITLE
Fix: Use magic methods instead of magic properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ For a full diff see [`1.4.0...1.5.0`][1.4.0...1.5.0].
 
 * Updated `fakerphp/faker` ([#434]), by [@dependabot]
 
+### Fixed
+
+* Stopped using deprecated magic properties on `Faker\Generator` and started using magic functions instead ([#435]), by [@localheinz]
+
 ## [`1.4.0`][1.4.0]
 
 For a full diff see [`1.3.0...1.4.0`][1.3.1...1.4.0].
@@ -178,6 +182,7 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [#372]: https://github.com/ergebnis/test-util/pull/372
 [#374]: https://github.com/ergebnis/test-util/pull/374
 [#434]: https://github.com/ergebnis/test-util/pull/434
+[#435]: https://github.com/ergebnis/test-util/pull/435
 
 [@dependabot]: https://github.com/dependabot
 [@ergebnis]: https://github.com/ergebnis

--- a/src/DataProvider/StringProvider.php
+++ b/src/DataProvider/StringProvider.php
@@ -89,8 +89,8 @@ final class StringProvider
         $faker = self::faker();
 
         $arbitraryValues = [
-            'string-arbitrary-sentence' => $faker->sentence,
-            'string-arbitrary-word' => $faker->word,
+            'string-arbitrary-sentence' => $faker->sentence(),
+            'string-arbitrary-word' => $faker->word(),
         ];
 
         $whitespaceCharacters = self::whitespaceCharacters();
@@ -125,7 +125,7 @@ final class StringProvider
                         $whitespaceCharacter,
                         $faker->numberBetween(1, 5)
                     ),
-                    $faker->word,
+                    $faker->word(),
                     \str_repeat(
                         $whitespaceCharacter,
                         $faker->numberBetween(1, 5)


### PR DESCRIPTION
This pull request

* [x] uses magic methods instead of deprecated magic properties

Follows #434.